### PR TITLE
feat: Add catppuccin theme for syntax highlight

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import remarkToc from "remark-toc";
 import remarkCollapse from "remark-collapse";
 import sitemap from "@astrojs/sitemap";
 import { SITE } from "./src/config";
+import shikiTheme from "./shiki/shiki-macchiato-theme.json"
 
 // https://astro.build/config
 export default defineConfig({
@@ -29,7 +30,7 @@ export default defineConfig({
       ],
     ],
     shikiConfig: {
-      theme: "one-dark-pro",
+      theme: shikiTheme,
       wrap: true,
     },
     extendDefaultPlugins: true,

--- a/shiki/shiki-frappe-theme.json
+++ b/shiki/shiki-frappe-theme.json
@@ -1,0 +1,2798 @@
+{
+  "name": "Catppuccin Frappe",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "semanticTokenColors": {
+    "enumMember": {
+      "foreground": "#99d1db"
+    },
+    "variable.constant": {
+      "foreground": "#e5c890"
+    },
+    "variable.defaultLibrary": {
+      "foreground": "#ef9f76"
+    }
+  },
+  "tokenColors": [
+    {
+      "name": "All variable",
+      "scope": ["variable.language", "variable.other"],
+      "settings": {
+        "foreground": "#eebebe"
+      }
+    },
+    {
+      "name": "All function",
+      "scope": ["entity.name.function", "support.function"],
+      "settings": {
+        "foreground": "#8caaee",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All parameter",
+      "scope": [
+        "variable.parameter.function",
+        "variable.parameter.function-call"
+      ],
+      "settings": {
+        "foreground": "#f4b8e4",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All numeric",
+      "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
+      "settings": {
+        "foreground": "#ef9f76",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All types",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "All conditionals",
+      "scope": [
+        "keyword.control",
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#e78284",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All punctuation brackets",
+      "scope": [
+        "punctuation.brackets",
+        "punctuation.section",
+        "punctuation.definition"
+      ],
+      "settings": {
+        "foreground": "#838ba7"
+      }
+    },
+    {
+      "name": "All punctuation delimiters",
+      "scope": "punctuation.semi",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "All namespace",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#f2d5cf"
+      }
+    },
+    {
+      "name": "All operators",
+      "scope": [
+        "keyword.operator.comparison",
+        "keyword.operator.assignment",
+        "keyword.operator.arrow.skinny",
+        "keyword.operator.math",
+        "keyword.operator.key-value",
+        "keyword.operator.misc",
+        "keyword.operator.namespace"
+      ],
+      "settings": {
+        "foreground": "#99d1db",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All built-in constants",
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#babbf1",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All constants",
+      "scope": "constant.other",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "JSON quoted string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "JSON punctuation string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "JSON punct structure",
+      "scope": [
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json",
+        "source.json meta.structure.array.json > value.json > string.quoted.json",
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation",
+        "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+      ],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "JSON property name",
+      "scope": "support.type.property-name.json.comments",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "JSON constants",
+      "scope": "constant.language.json.comments",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "JSON punctuation",
+      "scope": [
+        "punctuation.separator.dictionary.pair.json.comments",
+        "punctuation.separator.array.json.comments"
+      ],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "JSON brackets",
+      "scope": [
+        "punctuation.definition.dictionary.begin.json.comments",
+        "punctuation.definition.dictionary.end.json.comments",
+        "punctuation.definition.array.begin.json.comments",
+        "punctuation.definition.array.end.json.comments"
+      ],
+      "settings": {
+        "foreground": "#949cbb"
+      }
+    },
+    {
+      "name": "JSON constant language",
+      "scope": [
+        "source.json meta.structure.dictionary.json > constant.language.json",
+        "source.json meta.structure.array.json > constant.language.json"
+      ],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "JSON property name [VSCODE-CUSTOM]",
+      "scope": "support.type.property-name.json",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "unison punctuation",
+      "scope": [
+        "punctuation.definition.delayed.unison",
+        "punctuation.definition.list.begin.unison",
+        "punctuation.definition.list.end.unison",
+        "punctuation.definition.ability.begin.unison",
+        "punctuation.definition.ability.end.unison",
+        "punctuation.operator.assignment.as.unison",
+        "punctuation.separator.pipe.unison",
+        "punctuation.separator.delimiter.unison",
+        "punctuation.definition.hash.unison"
+      ],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "haskell variable generic-type",
+      "scope": "variable.other.generic-type.haskell",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "haskell storage type",
+      "scope": "storage.type.haskell",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "support.variable.magic.python",
+      "scope": "support.variable.magic.python",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "punctuation.separator.parameters.python",
+      "scope": [
+        "punctuation.separator.period.python",
+        "punctuation.separator.element.python",
+        "punctuation.parenthesis.begin.python",
+        "punctuation.parenthesis.end.python"
+      ],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.self.python",
+      "scope": "variable.parameter.function.language.special.self.python",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Rust modifier",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Rust types",
+      "scope": "entity.name.type.rust",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Rust functions std",
+      "scope": "support.function.std.rust",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Rust functions",
+      "scope": "entity.name.function.rust",
+      "settings": {
+        "foreground": "#8caaee",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust function keyword",
+      "scope": "keyword.other.fn.rust",
+      "settings": {
+        "foreground": "#ea999c"
+      }
+    },
+    {
+      "name": "Rust conditionals",
+      "scope": "keyword.control.rust",
+      "settings": {
+        "foreground": "#ca9ee6",
+        "fontStyle": "bold italic"
+      }
+    },
+    {
+      "name": "Rust punctuation brackets",
+      "scope": [
+        "punctuation.brackets.curly.rust",
+        "punctuation.brackets.round.rust",
+        "punctuation.brackets.square.rust",
+        "punctuation.brackets.attribute.rust"
+      ],
+      "settings": {
+        "foreground": "#838ba7"
+      }
+    },
+    {
+      "name": "Rust namespace",
+      "scope": "entity.name.namespace.rust",
+      "settings": {
+        "foreground": "#f2d5cf"
+      }
+    },
+    {
+      "name": "Rust punctuation delimiters",
+      "scope": "punctuation.semi.rust",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Rust operators",
+      "scope": [
+        "keyword.operator.comparison.rust",
+        "keyword.operator.assignment.equal.rust",
+        "keyword.operator.arrow.skinny.rust",
+        "keyword.operator.math.rust",
+        "keyword.operator.key-value.rust",
+        "keyword.operator.misc.rust"
+      ],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Rust operator namespaces",
+      "scope": "keyword.operator.namespace.rust",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Rust definition attributes",
+      "scope": [
+        "punctuation.definition.attribute.rust",
+        "keyword.operator.attribute.inner.rust"
+      ],
+      "settings": {
+        "foreground": "#81c8be",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Rust math logic",
+      "scope": "constant.numeric.decimal.rust",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Rust constants",
+      "scope": "support.constant.core.rust",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Rust entity name",
+      "scope": "entity.name.lifetime.rust",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Rust variable",
+      "scope": ["variable.language.rust", "variable.other.rust"],
+      "settings": {
+        "foreground": "#c6d0f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust misc operators",
+      "scope": "keyword.operator.misc.rust",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Rust sigil operator",
+      "scope": "keyword.operator.sigil.rust",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Lua operators",
+      "scope": "keyword.operator.lua",
+      "settings": {
+        "foreground": "#99d1db",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua numeric",
+      "scope": "constant.numeric.integer.lua",
+      "settings": {
+        "foreground": "#ef9f76",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua other vars",
+      "scope": "variable.other.lua",
+      "settings": {
+        "foreground": "#babbf1",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Lua brackets",
+      "scope": [
+        "punctuation.definition.parameters.end.lua",
+        "punctuation.definition.parameters.begin.lua"
+      ],
+      "settings": {
+        "foreground": "#838ba7"
+      }
+    },
+    {
+      "name": "C++ Punct Delimiters",
+      "scope": "punctuation.terminator.statement.cpp",
+      "settings": {
+        "foreground": "#81c8be",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ Variables",
+      "scope": "variable.other.local.cpp",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "C++ Operators",
+      "scope": [
+        "punctuation.separator.scope-resolution.cpp",
+        "punctuation.separator.scope-resolution.namespace.alias.cpp",
+        "punctuation.separator.scope-resolution.namespace.using.cpp"
+      ],
+      "settings": {
+        "foreground": "#99d1db",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ function",
+      "scope": "meta.function.c,meta.function.cpp",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "C++ constructor/destructor",
+      "scope": [
+        "entity.name.function.definition.special.constructor",
+        "entity.name.function.definition.special.member.destructor"
+      ],
+      "settings": {
+        "foreground": "#babbf1"
+      }
+    },
+    {
+      "name": "C++ directive",
+      "scope": [
+        "keyword.control.directive",
+        "keyword.other.using.directive",
+        "punctuation.definition.directive"
+      ],
+      "settings": {
+        "foreground": "#81c8be",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ ifdef directive",
+      "scope": [
+        "keyword.control.directive.conditional.ifdef.cpp",
+        "keyword.control.directive.else.cpp",
+        "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp",
+        "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
+      ],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "C++ misc",
+      "scope": [
+        "entity.name.other.preprocessor.macro.predefined.probably",
+        "entity.name.scope-resolution.cpp"
+      ],
+      "settings": {
+        "foreground": "#f2d5cf",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ pointer/reference",
+      "scope": [
+        "storage.modifier.pointer.cpp",
+        "storage.modifier.reference.cpp"
+      ],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "C++ loop/conditional",
+      "scope": [
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#ca9ee6",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ return",
+      "scope": "keyword.control.return",
+      "settings": {
+        "foreground": "#f4b8e4"
+      }
+    },
+    {
+      "name": "C++ block",
+      "scope": [
+        "punctuation.section.block.begin.bracket.curly.cpp",
+        "punctuation.section.block.end.bracket.curly.cpp",
+        "punctuation.terminator.statement.c",
+        "punctuation.section.block.begin.bracket.curly.c",
+        "punctuation.section.block.end.bracket.curly.c",
+        "punctuation.section.parens.begin.bracket.round.c",
+        "punctuation.section.parens.end.bracket.round.c",
+        "punctuation.section.parameters.begin.bracket.round.c",
+        "punctuation.section.parameters.end.bracket.round.c"
+      ],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "C++ storage type modifier",
+      "scope": "storage.type.built-in.primitive.cpp",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "C++/C#",
+      "scope": [
+        "entity.name.label.cs",
+        "entity.name.scope-resolution.function.call",
+        "entity.name.scope-resolution.function.definition"
+      ],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "support.constant.edge",
+      "scope": "support.constant.edge",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "regexp constant character-class",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "regexp operator.quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "punctuation.definition",
+      "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": "comment markup.link",
+      "settings": {
+        "foreground": "#737994"
+      }
+    },
+    {
+      "name": "markup diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "diff",
+      "scope": [
+        "meta.diff.header.from-file",
+        "meta.diff.header.to-file",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.to-file.diff"
+      ],
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "inserted.diff",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "deleted.diff",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Quote multi",
+      "scope": [
+        "string.quoted.docstring.multi",
+        "string.quoted.multi",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.end.python",
+        "markup.fenced_code.block"
+      ],
+      "settings": {
+        "foreground": "#a6d189",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "js/ts punctuation separator key-value",
+      "scope": "punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "js/ts import keyword",
+      "scope": "keyword.operator.expression.import",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "math js/ts",
+      "scope": "support.constant.math",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "math property js/ts",
+      "scope": "support.constant.property.math",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "js/ts variable.other.constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "java type",
+      "scope": [
+        "storage.type.annotation.java",
+        "storage.type.object.array.java"
+      ],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "java source",
+      "scope": "source.java",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": [
+        "punctuation.section.block.begin.java",
+        "punctuation.section.block.end.java",
+        "punctuation.definition.method-parameters.begin.java",
+        "punctuation.definition.method-parameters.end.java",
+        "meta.method.identifier.java",
+        "punctuation.section.method.begin.java",
+        "punctuation.section.method.end.java",
+        "punctuation.terminator.java",
+        "punctuation.section.class.begin.java",
+        "punctuation.section.class.end.java",
+        "punctuation.section.inner-class.begin.java",
+        "punctuation.section.inner-class.end.java",
+        "meta.method-call.java",
+        "punctuation.section.class.begin.bracket.curly.java",
+        "punctuation.section.class.end.bracket.curly.java",
+        "punctuation.section.method.begin.bracket.curly.java",
+        "punctuation.section.method.end.bracket.curly.java",
+        "punctuation.separator.period.java",
+        "punctuation.bracket.angle.java",
+        "punctuation.definition.annotation.java",
+        "meta.method.body.java"
+      ],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "meta.method.java",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "java variable.name",
+      "scope": "meta.definition.variable.name.java",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "operator logical",
+      "scope": ["keyword.operator.logical", "keyword.operator.ternary"],
+      "settings": {
+        "foreground": "#99d1db",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "operator bitwise",
+      "scope": "keyword.operator.bitwise",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "support.constant.property-value.scss",
+      "scope": [
+        "support.constant.property-value.scss",
+        "support.constant.property-value.css"
+      ],
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": [
+        "keyword.operator.css",
+        "keyword.operator.scss",
+        "keyword.operator.less"
+      ],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "css color standard name",
+      "scope": [
+        "support.constant.color.w3c-standard-color-name.css",
+        "support.constant.color.w3c-standard-color-name.scss"
+      ],
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "css comma",
+      "scope": "punctuation.separator.list.comma.css",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "css attribute-name.id",
+      "scope": "support.constant.color.w3c-standard-color-name.css",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "css property-name",
+      "scope": "support.type.vendored.property-name.css",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "js/ts module",
+      "scope": [
+        "support.module.node",
+        "support.type.object.module",
+        "support.module.node"
+      ],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "entity.name.type.module",
+      "scope": "entity.name.type.module",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "js variable readwrite",
+      "scope": [
+        "variable.other.readwrite",
+        "meta.object-literal.key",
+        "support.variable.property",
+        "support.variable.object.process",
+        "support.variable.object.node"
+      ],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "js/ts json",
+      "scope": "support.constant.json",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "js/ts Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.ternary",
+        "keyword.operator.optional",
+        "keyword.operator.expression.keyof"
+      ],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "js/ts console",
+      "scope": "support.type.object.console",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "js/ts support.variable.property.process",
+      "scope": "support.variable.property.process",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "js console function",
+      "scope": "entity.name.function,support.function.console",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "operator",
+      "scope": "keyword.operator.delete",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "js dom",
+      "scope": "support.type.object.dom",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "js dom variable",
+      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": [
+        "keyword.operator.arithmetic",
+        "keyword.operator.comparison",
+        "keyword.operator.decrement",
+        "keyword.operator.increment",
+        "keyword.operator.relational"
+      ],
+      "settings": {
+        "foreground": "#99d1db",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C operators",
+      "scope": [
+        "keyword.operator.c",
+        "keyword.operator.increment.c",
+        "keyword.operator.decrement.c",
+        "keyword.operator.bitwise.shift.c",
+        "keyword.operator.cpp",
+        "keyword.operator.increment.cpp",
+        "keyword.operator.decrement.cpp",
+        "keyword.operator.bitwise.shift.cpp"
+      ],
+      "settings": {
+        "foreground": "#99d1db",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Other punctuation .c",
+      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "C type posix-reserved",
+      "scope": [
+        "support.type.posix-reserved.c",
+        "support.type.posix-reserved.cpp"
+      ],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "keyword.operator.sizeof.c",
+      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "python type",
+      "scope": "support.type.python",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "python block",
+      "scope": [
+        "punctuation.definition.arguments.begin.python",
+        "punctuation.definition.arguments.end.python",
+        "punctuation.separator.arguments.python",
+        "punctuation.definition.list.begin.python",
+        "punctuation.definition.list.end.python"
+      ],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "python function-call.generic",
+      "scope": "meta.function-call.generic.python",
+      "settings": {
+        "foreground": "#8caaee",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#99d1db",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Java Variables",
+      "scope": "token.variable.parameter.java",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Java Imports",
+      "scope": "import.storage.java",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package.keyword",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Functions",
+      "scope": [
+        "entity.name.function",
+        "meta.require",
+        "support.function.any-method",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#8caaee",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "entity.name.type.namespace",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "support.class, entity.name.type.class",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": "entity.name.class.identifier.namespace.type",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "variable.other.class.js",
+        "variable.other.class.ts"
+      ],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Class name php",
+      "scope": "variable.other.class.php",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Type Name",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Control Elements",
+      "scope": "control.elements, keyword.operator.less",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Methods",
+      "scope": "keyword.other.special-method",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Storage JS TS",
+      "scope": "token.storage",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete, In, Of, Instanceof, New, Typeof, Void",
+      "scope": [
+        "keyword.operator.expression.delete",
+        "keyword.operator.expression.in",
+        "keyword.operator.expression.of",
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.expression.typeof",
+        "keyword.operator.expression.void"
+      ],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Java Storage",
+      "scope": "token.storage.type.java",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Support",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.property-value",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.font-name",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Meta tag",
+      "scope": "meta.tag",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": "string",
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "Inherited Class",
+      "scope": "entity.other.inherited-class",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Constant other symbol",
+      "scope": "constant.other.symbol",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Integers",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "constant",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "punctuation.definition.constant",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Tags",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#ca9ee6"
+      }
+    },
+    {
+      "name": "Attributes",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Attribute IDs",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Attribute class",
+      "scope": "entity.other.attribute-name.class.css",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "SCSS variables",
+      "scope": "variable.scss",
+      "settings": {
+        "foreground": "#ca9ee6"
+      }
+    },
+    {
+      "name": "Selector",
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Units",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "markup.bold,todo.bold",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "punctuation.definition.bold",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "markup Italic",
+      "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "emphasis md",
+      "scope": "emphasis md",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "punctuation.definition.list.begin.markdown",
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "punctuation.definition.list.markdown",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "beginning.punctuation.definition.list.markdown",
+      "scope": ["beginning.punctuation.definition.list.markdown"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Regular Expressions",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Escape Characters",
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded, variable.interpolation",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "illegal, deprecated",
+      "scope": "invalid.illegal, invalid.deprecated",
+      "settings": {
+        "foreground": "#737994",
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal.bad-ampersand.html",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Broken",
+      "scope": "invalid.broken",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Unimplemented",
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "foreground": "#a5adce"
+      }
+    },
+    {
+      "name": "laravel blade tag",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "laravel blade @",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "use statement for other classes",
+      "scope": [
+        "support.other.namespace.use.php",
+        "support.other.namespace.use-as.php",
+        "support.other.namespace.php",
+        "entity.other.alias.php",
+        "meta.interface.php"
+      ],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "error suppression",
+      "scope": "keyword.operator.error-control.php",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "php instanceof",
+      "scope": "keyword.operator.type.php",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "style double quoted array index normal begin",
+      "scope": "punctuation.section.array.begin.php",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "style double quoted array index normal end",
+      "scope": "punctuation.section.array.end.php",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "php illegal.non-null-typehinted",
+      "scope": "invalid.illegal.non-null-typehinted.php",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "php types",
+      "scope": [
+        "storage.type.php",
+        "meta.other.type.phpdoc.php",
+        "keyword.other.type.php",
+        "keyword.other.array.phpdoc.php"
+      ],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "php call-function",
+      "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "php function-resets",
+      "scope": [
+        "punctuation.definition.parameters.begin.bracket.round.php",
+        "punctuation.definition.parameters.end.bracket.round.php",
+        "punctuation.separator.delimiter.php",
+        "punctuation.section.scope.begin.php",
+        "punctuation.section.scope.end.php",
+        "punctuation.terminator.expression.php",
+        "punctuation.definition.arguments.begin.bracket.round.php",
+        "punctuation.definition.arguments.end.bracket.round.php",
+        "punctuation.definition.storage-type.begin.bracket.round.php",
+        "punctuation.definition.storage-type.end.bracket.round.php",
+        "punctuation.definition.array.begin.bracket.round.php",
+        "punctuation.definition.array.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.round.php",
+        "punctuation.definition.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.curly.php",
+        "punctuation.definition.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.start.bracket.curly.php",
+        "punctuation.definition.section.switch-block.begin.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php"
+      ],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": [
+        "support.constant.ext.php",
+        "support.constant.std.php",
+        "support.constant.core.php",
+        "support.constant.parser-token.php"
+      ],
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "php goto",
+      "scope": "entity.name.goto-label.php,support.other.php",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "php logical/bitwise operator",
+      "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "php regexp operator",
+      "scope": "keyword.operator.regexp.php",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "php comparison",
+      "scope": "keyword.operator.comparison.php",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "php heredoc/nowdoc",
+      "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "python function decorator @",
+      "scope": "meta.function.decorator.python",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": [
+        "support.token.decorator.python",
+        "meta.function.decorator.identifier.python"
+      ],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "parameter function js/ts",
+      "scope": "function.parameter",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "brace function",
+      "scope": "function.brace",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "parameter function ruby cs",
+      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "constant.language.symbol.ruby",
+      "scope": "constant.language.symbol.ruby",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "rgb-value",
+      "scope": "rgb-value",
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "rgb value",
+      "scope": "inline-color-decoration rgb-value",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "rgb value less",
+      "scope": "less rgb-value",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "sass selector",
+      "scope": "selector.sass",
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "ts primitive/builtin types",
+      "scope": [
+        "support.type.primitive.ts",
+        "support.type.builtin.ts",
+        "support.type.primitive.tsx",
+        "support.type.builtin.tsx"
+      ],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "block scope",
+      "scope": "block.scope.end,block.scope.begin",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "cs storage type",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "cs local variable",
+      "scope": "entity.name.variable.local.cs",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": ["meta.template.expression"],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Import module JS",
+      "scope": ["keyword.operator.module"],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "js Flowtype",
+      "scope": ["support.type.type.flowtype"],
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "js Flow",
+      "scope": ["support.type.primitive"],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "js class prop",
+      "scope": ["meta.property.object"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "js func parameter",
+      "scope": ["variable.parameter.function.js"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "js template literals begin",
+      "scope": ["keyword.other.template.begin"],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "js template literals end",
+      "scope": ["keyword.other.template.end"],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "js template literals variable braces begin",
+      "scope": ["keyword.other.substitution.begin"],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "js template literals variable braces end",
+      "scope": ["keyword.other.substitution.end"],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.arithmetic.go",
+        "keyword.operator.address.go"
+      ],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "Go package name",
+      "scope": ["entity.name.package.go"],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Go import statement",
+      "scope": "keyword.import.go",
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "elm prelude",
+      "scope": ["support.type.prelude.elm"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "elm constant",
+      "scope": ["support.constant.elm"],
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": ["punctuation.quasi.element"],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": ["constant.character.entity"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+      "scope": [
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.pseudo-class"
+      ],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": ["entity.global.clojure"],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": ["meta.symbol.clojure"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": ["constant.keyword.clojure"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": ["source.ini"],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "Shell definition variables",
+      "scope": ["punctuation.definition.variable.shell"],
+      "settings": {
+        "foreground": "#838ba7"
+      }
+    },
+    {
+      "name": "Shell logical operators",
+      "scope": ["keyword.operator.logical.shell"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Shell clauses",
+      "scope": ["meta.scope.case-clause-body.shell"],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Shell funcs",
+      "scope": ["meta.scope.group.shell"],
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Shell interpolated cmds",
+      "scope": ["string.interpolated.dollar.shell"],
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "Shell interpolated strings",
+      "scope": ["string.quoted.single.shell"],
+      "settings": {
+        "foreground": "#babbf1"
+      }
+    },
+    {
+      "name": "Shell pipe symbol",
+      "scope": ["keyword.operator.pipe.shell"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "Shell group definition",
+      "scope": ["punctuation.definition.group.shell"],
+      "settings": {
+        "foreground": "#838ba7"
+      }
+    },
+    {
+      "name": "Shell conditionals",
+      "scope": ["keyword.control.shell"],
+      "settings": {
+        "foreground": "#ca9ee6"
+      }
+    },
+    {
+      "name": "Shell operators and punct delimiters",
+      "scope": ["keyword.operator.list.shell"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Shell parenthesis",
+      "scope": ["punctuation.definition.logical-expression.shell"],
+      "settings": {
+        "foreground": "#838ba7"
+      }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": ["meta.scope.prerequisites.makefile"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": ["source.makefile"],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": ["storage.modifier.import.groovy"],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": ["meta.method.groovy"],
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": ["meta.definition.variable.name.groovy"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": ["meta.definition.class.inherited.classes.groovy"],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": ["support.variable.semantic.hlsl"],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "SQL Variables",
+      "scope": ["text.variable", "text.bracketed"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "types",
+      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "settings": {
+        "foreground": "#ef9f76"
+      }
+    },
+    {
+      "name": "heading 1, keyword",
+      "scope": ["entity.name.function.xi"],
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "heading 2, callable",
+      "scope": ["entity.name.class.xi"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "heading 3, property",
+      "scope": ["constant.character.character-class.regexp.xi"],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "heading 4, type, class, interface",
+      "scope": ["constant.regexp.xi"],
+      "settings": {
+        "foreground": "#e78284"
+      }
+    },
+    {
+      "name": "heading 5, enums, preprocessor, constant, decorator",
+      "scope": ["keyword.control.xi"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "heading 6, number",
+      "scope": ["invalid.xi"],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "string",
+      "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+      "settings": {
+        "foreground": "#a6d189"
+      }
+    },
+    {
+      "name": "comments",
+      "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+      "settings": {
+        "foreground": "#737994"
+      }
+    },
+    {
+      "name": "link",
+      "scope": ["constant.character.xi"],
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "accent",
+      "scope": ["accent.xi"],
+      "settings": {
+        "foreground": "#8caaee"
+      }
+    },
+    {
+      "name": "wikiword",
+      "scope": ["wikiword.xi"],
+      "settings": {
+        "foreground": "#e5c890"
+      }
+    },
+    {
+      "name": "language operators like '+', '-' etc",
+      "scope": ["constant.other.color.rgb-value.xi"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "elements to dim",
+      "scope": ["punctuation.definition.tag.xi"],
+      "settings": {
+        "foreground": "#737994"
+      }
+    },
+    {
+      "name": "Markdown underscore-style headers",
+      "scope": [
+        "entity.name.label.cs",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.setext.2.markdown"
+      ],
+      "settings": {
+        "foreground": "#81c8be"
+      }
+    },
+    {
+      "name": "meta.brace.square",
+      "scope": [" meta.brace.square"],
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": "comment, punctuation.definition.comment",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#737994"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": {
+        "foreground": "#737994"
+      }
+    },
+    {
+      "name": "punctuation.definition.block.sequence.item.yaml",
+      "scope": "punctuation.definition.block.sequence.item.yaml",
+      "settings": {
+        "foreground": "#c6d0f5"
+      }
+    },
+    {
+      "scope": ["constant.language.symbol.elixir"],
+      "settings": {
+        "foreground": "#99d1db"
+      }
+    },
+    {
+      "name": "js/ts italic",
+      "scope": [
+        "entity.other.attribute-name.js",
+        "entity.other.attribute-name.ts",
+        "entity.other.attribute-name.jsx",
+        "entity.other.attribute-name.tsx",
+        "variable.parameter",
+        "variable.language.super"
+      ],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "comment",
+      "scope": "comment.line.double-slash,comment.block.documentation",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword import",
+      "scope": "keyword.control.import.python",
+      "settings": {
+        "foreground": "#81c8be",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword flow",
+      "scope": "keyword.control.flow.python",
+      "settings": {
+        "foreground": "#ca9ee6",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "python storage type",
+      "scope": "storage.type.function.python",
+      "settings": {
+        "foreground": "#ea999c",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "markup.italic.markdown",
+      "scope": "markup.italic.markdown",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "invalid.deprecated.line-too-long.git-commit",
+      "scope": "invalid.deprecated.line-too-long.git-commit",
+      "settings": {
+        "foreground": "#e5c890",
+        "fontStyle": "underline"
+      }
+    }
+  ],
+  "colors": {
+    "focusBorder": "#00000000",
+    "foreground": "#c6d0f5",
+    "disabledForeground": "#a5adce",
+    "widget.shadow": "#292c3c7f",
+    "selection.background": "#626880",
+    "descriptionForeground": "#c6d0f5",
+    "errorForeground": "#e78284",
+    "icon.foreground": "#ca9ee6",
+    "sash.hoverBorder": "#ca9ee6",
+    "window.activeBorder": "#00000000",
+    "window.inactiveBorder": "#00000000",
+    "textBlockQuote.background": "#292c3c",
+    "textBlockQuote.border": "#232634",
+    "textCodeBlock.background": "#303446",
+    "textLink.activeForeground": "#99d1db",
+    "textLink.foreground": "#8caaee",
+    "textPreformat.foreground": "#c6d0f5",
+    "textSeparator.foreground": "#ca9ee6",
+    "activityBar.background": "#232634",
+    "activityBar.foreground": "#ca9ee6",
+    "activityBar.dropBar": "#62688099",
+    "activityBar.inactiveForeground": "#737994",
+    "activityBar.border": "#00000000",
+    "activityBarBadge.background": "#ca9ee6",
+    "activityBarBadge.foreground": "#232634",
+    "activityBar.activeBorder": "#00000000",
+    "activityBar.activeBackground": "#00000000",
+    "activityBar.activeFocusBorder": "#00000000",
+    "badge.background": "#51576d",
+    "badge.foreground": "#c6d0f5",
+    "breadcrumb.activeSelectionForeground": "#ca9ee6",
+    "breadcrumb.background": "#292c3c",
+    "breadcrumb.focusForeground": "#ca9ee6",
+    "breadcrumb.foreground": "#c6d0f5cc",
+    "breadcrumbPicker.background": "#292c3c",
+    "button.background": "#ca9ee6",
+    "button.foreground": "#232634",
+    "button.border": "#00000000",
+    "button.separator": "#00000000",
+    "button.hoverBackground": "#deb2fa",
+    "button.secondaryForeground": "#c6d0f5",
+    "button.secondaryBackground": "#626880",
+    "button.secondaryHoverBackground": "#767c94",
+    "checkbox.background": "#51576d",
+    "checkbox.border": "#00000000",
+    "checkbox.foreground": "#ca9ee6",
+    "dropdown.background": "#292c3c",
+    "dropdown.listBackground": "#626880",
+    "dropdown.border": "#ca9ee6",
+    "dropdown.foreground": "#c6d0f5",
+    "debugToolBar.background": "#232634",
+    "debugToolBar.border": "#00000000",
+    "debugExceptionWidget.background": "#232634",
+    "debugExceptionWidget.border": "#ca9ee6",
+    "debugTokenExpression.number": "#ef9f76",
+    "debugTokenExpression.boolean": "#ca9ee6",
+    "debugTokenExpression.string": "#a6d189",
+    "debugTokenExpression.error": "#e78284",
+    "debugIcon.breakpointForeground": "#e78284",
+    "debugIcon.breakpointDisabledForeground": "#e7828499",
+    "debugIcon.breakpointUnverifiedForeground": "#303446",
+    "debugIcon.breakpointCurrentStackframeForeground": "#626880",
+    "debugIcon.breakpointStackframeForeground": "#626880",
+    "debugIcon.startForeground": "#a6d189",
+    "debugIcon.pauseForeground": "#8caaee",
+    "debugIcon.stopForeground": "#e78284",
+    "debugIcon.disconnectForeground": "#626880",
+    "debugIcon.restartForeground": "#81c8be",
+    "debugIcon.stepOverForeground": "#ca9ee6",
+    "debugIcon.stepIntoForeground": "#c6d0f5",
+    "debugIcon.stepOutForeground": "#c6d0f5",
+    "debugIcon.continueForeground": "#a6d189",
+    "debugIcon.stepBackForeground": "#626880",
+    "debugConsole.infoForeground": "#8caaee",
+    "debugConsole.warningForeground": "#ef9f76",
+    "debugConsole.errorForeground": "#e78284",
+    "debugConsole.sourceForeground": "#f2d5cf",
+    "debugConsoleInputIcon.foreground": "#c6d0f5",
+    "diffEditor.border": "#626880",
+    "diffEditor.insertedTextBackground": "#a6d18919",
+    "diffEditor.removedTextBackground": "#e7828419",
+    "diffEditor.insertedLineBackground": "#a6d18926",
+    "diffEditor.removedLineBackground": "#e7828426",
+    "diffEditor.diagonalFill": "#62688099",
+    "diffEditorOverview.insertedForeground": "#a6d189cc",
+    "diffEditorOverview.removedForeground": "#e78284cc",
+    "editor.background": "#303446",
+    "editor.findMatchBackground": "#626880",
+    "editor.findMatchBorder": "#ca9ee666",
+    "editor.findMatchHighlightBackground": "#ef9f7659",
+    "editor.findMatchHighlightBorder": "#00000000",
+    "editor.findRangeHighlightBackground": "#6268804c",
+    "editor.findRangeHighlightBorder": "#00000000",
+    "editor.foldBackground": "#99d1db3f",
+    "editor.foreground": "#c6d0f5",
+    "editor.hoverHighlightBackground": "#99d1db3f",
+    "editor.inactiveSelectionBackground": "#00000000",
+    "editor.lineHighlightBackground": "#c6d0f511",
+    "editor.lineHighlightBorder": "#303446",
+    "editor.rangeHighlightBackground": "#99d1db3f",
+    "editor.rangeHighlightBorder": "#00000000",
+    "editor.selectionBackground": "#626880",
+    "editor.selectionHighlightBackground": "#949cbb66",
+    "editor.selectionHighlightBorder": "#99d1db33",
+    "editor.wordHighlightBackground": "#626880b2",
+    "editor.wordHighlightStrongBackground": "#6268807f",
+    "editorBracketMatch.background": "#949cbb19",
+    "editorBracketMatch.border": "#949cbb",
+    "editorCodeLens.foreground": "#838ba7",
+    "editorCursor.background": "#303446",
+    "editorCursor.foreground": "#f2d5cf",
+    "editorError.background": "#00000000",
+    "editorError.border": "#00000000",
+    "editorError.foreground": "#e78284",
+    "editorGroup.border": "#626880",
+    "editorGroup.dropBackground": "#62688099",
+    "editorGroup.emptyBackground": "#303446",
+    "editorGroupHeader.tabsBackground": "#232634",
+    "editorGutter.addedBackground": "#a6d189",
+    "editorGutter.background": "#303446",
+    "editorGutter.commentRangeForeground": "#949cbb",
+    "editorGutter.deletedBackground": "#e78284",
+    "editorGutter.foldingControlForeground": "#949cbb",
+    "editorGutter.modifiedBackground": "#99d1db",
+    "editorHoverWidget.background": "#292c3c",
+    "editorHoverWidget.border": "#626880",
+    "editorHoverWidget.foreground": "#c6d0f5",
+    "editorIndentGuide.activeBackground": "#626880",
+    "editorIndentGuide.background": "#51576d",
+    "editorInfo.background": "#00000000",
+    "editorInfo.border": "#00000000",
+    "editorInfo.foreground": "#8caaee",
+    "editorInlayHint.foreground": "#626880",
+    "editorInlayHint.background": "#292c3cbf",
+    "editorInlayHint.typeForeground": "#b5bfe2",
+    "editorInlayHint.typeBackground": "#292c3cbf",
+    "editorInlayHint.parameterForeground": "#a5adce",
+    "editorInlayHint.parameterBackground": "#292c3cbf",
+    "editorLineNumber.activeForeground": "#ca9ee6",
+    "editorLineNumber.foreground": "#838ba7",
+    "editorLink.activeForeground": "#ca9ee6",
+    "editorMarkerNavigation.background": "#292c3c",
+    "editorMarkerNavigationError.background": "#e78284",
+    "editorMarkerNavigationInfo.background": "#8caaee",
+    "editorMarkerNavigationWarning.background": "#e5c890",
+    "editorOverviewRuler.background": "#292c3c",
+    "editorOverviewRuler.border": "#c6d0f511",
+    "editorRuler.foreground": "#626880",
+    "editor.stackFrameHighlightBackground": "#e5c89026",
+    "editor.focusedStackFrameHighlightBackground": "#a6d18926",
+    "editorStickyScrollHover.background": "#414559",
+    "editorSuggestWidget.background": "#292c3c",
+    "editorSuggestWidget.border": "#626880",
+    "editorSuggestWidget.foreground": "#c6d0f5",
+    "editorSuggestWidget.highlightForeground": "#ca9ee6",
+    "editorSuggestWidget.selectedBackground": "#414559",
+    "editorWarning.background": "#00000000",
+    "editorWarning.border": "#00000000",
+    "editorWarning.foreground": "#ef9f76",
+    "editorWhitespace.foreground": "#949cbb66",
+    "editorWidget.background": "#292c3c",
+    "editorWidget.foreground": "#c6d0f5",
+    "editorWidget.resizeBorder": "#626880",
+    "editorLightBulb.foreground": "#e5c890",
+    "extensionButton.prominentForeground": "#232634",
+    "extensionButton.prominentBackground": "#ca9ee6",
+    "extensionButton.prominentHoverBackground": "#deb2fa",
+    "extensionBadge.remoteBackground": "#8caaee",
+    "extensionBadge.remoteForeground": "#232634",
+    "extensionIcon.starForeground": "#e5c890",
+    "extensionIcon.verifiedForeground": "#a6d189",
+    "extensionIcon.preReleaseForeground": "#f2d5cf",
+    "extensionIcon.sponsorForeground": "#f4b8e4",
+    "gitDecoration.addedResourceForeground": "#a6d189",
+    "gitDecoration.conflictingResourceForeground": "#ca9ee6",
+    "gitDecoration.deletedResourceForeground": "#e78284",
+    "gitDecoration.ignoredResourceForeground": "#737994",
+    "gitDecoration.modifiedResourceForeground": "#e5c890",
+    "gitDecoration.stageDeletedResourceForeground": "#e78284",
+    "gitDecoration.stageModifiedResourceForeground": "#e5c890",
+    "gitDecoration.submoduleResourceForeground": "#8caaee",
+    "gitDecoration.untrackedResourceForeground": "#a6d189",
+    "input.background": "#414559",
+    "input.border": "#00000000",
+    "input.foreground": "#c6d0f5",
+    "input.placeholderForeground": "#c6d0f572",
+    "inputOption.activeBackground": "#8caaee26",
+    "inputOption.activeBorder": "#23263433",
+    "inputOption.activeForeground": "#c6d0f5",
+    "inputValidation.errorBackground": "#e78284",
+    "inputValidation.errorBorder": "#23263433",
+    "inputValidation.errorForeground": "#232634",
+    "inputValidation.infoBackground": "#8caaee",
+    "inputValidation.infoBorder": "#23263433",
+    "inputValidation.infoForeground": "#232634",
+    "inputValidation.warningBackground": "#ef9f76",
+    "inputValidation.warningBorder": "#23263433",
+    "inputValidation.warningForeground": "#232634",
+    "list.activeSelectionBackground": "#51576d",
+    "list.activeSelectionForeground": "#c6d0f5",
+    "list.dropBackground": "#62688099",
+    "list.focusBackground": "#414559",
+    "list.focusForeground": "#c6d0f5",
+    "list.focusOutline": "#00000000",
+    "list.highlightForeground": "#ca9ee6",
+    "list.hoverBackground": "#303446",
+    "list.hoverForeground": "#c6d0f5",
+    "list.inactiveSelectionBackground": "#51576d",
+    "list.inactiveSelectionForeground": "#c6d0f5",
+    "list.warningForeground": "#e5c890",
+    "listFilterWidget.background": "#51576d",
+    "listFilterWidget.noMatchesOutline": "#e78284",
+    "listFilterWidget.outline": "#00000000",
+    "tree.indentGuidesStroke": "#737994",
+    "menu.background": "#303446",
+    "menu.border": "#3034467f",
+    "menu.foreground": "#c6d0f5",
+    "menu.selectionBackground": "#626880",
+    "menu.selectionBorder": "#00000000",
+    "menu.selectionForeground": "#c6d0f5",
+    "menu.separatorBackground": "#626880",
+    "menubar.selectionBackground": "#51576d",
+    "menubar.selectionForeground": "#c6d0f5",
+    "merge.commonContentBackground": "#51576d",
+    "merge.commonHeaderBackground": "#626880",
+    "merge.currentContentBackground": "#a6d18933",
+    "merge.currentHeaderBackground": "#a6d18966",
+    "merge.incomingContentBackground": "#8caaee33",
+    "merge.incomingHeaderBackground": "#8caaee66",
+    "minimap.background": "#292c3c7f",
+    "minimap.errorHighlight": "#e78284",
+    "minimap.findMatchHighlight": "#626880",
+    "minimap.selectionHighlight": "#626880",
+    "minimap.warningHighlight": "#e5c890",
+    "minimapGutter.addedBackground": "#a6d189",
+    "minimapGutter.deletedBackground": "#e78284",
+    "minimapGutter.modifiedBackground": "#99d1db",
+    "notificationCenter.border": "#ca9ee6",
+    "notificationCenterHeader.foreground": "#c6d0f5",
+    "notificationCenterHeader.background": "#292c3c",
+    "notificationToast.border": "#ca9ee6",
+    "notifications.foreground": "#c6d0f5",
+    "notifications.background": "#292c3c",
+    "notifications.border": "#ca9ee6",
+    "notificationLink.foreground": "#8caaee",
+    "notificationsErrorIcon.foreground": "#e78284",
+    "notificationsWarningIcon.foreground": "#ef9f76",
+    "notificationsInfoIcon.foreground": "#8caaee",
+    "panel.background": "#303446",
+    "panel.border": "#626880",
+    "panelSection.border": "#626880",
+    "panelSection.dropBackground": "#62688099",
+    "panelTitle.activeBorder": "#c6d0f5",
+    "panelTitle.activeForeground": "#c6d0f5",
+    "panelTitle.inactiveForeground": "#a5adce",
+    "peekView.border": "#ca9ee6",
+    "peekViewEditor.background": "#292c3c",
+    "peekViewEditor.matchHighlightBackground": "#ef9f763f",
+    "peekViewEditor.matchHighlightBorder": "#ef9f76",
+    "peekViewEditorGutter.background": "#292c3c",
+    "peekViewResult.background": "#292c3c",
+    "peekViewResult.fileForeground": "#c6d0f5",
+    "peekViewResult.lineForeground": "#c6d0f5",
+    "peekViewResult.matchHighlightBackground": "#ef9f763f",
+    "peekViewResult.selectionBackground": "#414559",
+    "peekViewResult.selectionForeground": "#c6d0f5",
+    "peekViewTitle.background": "#303446",
+    "peekViewTitleDescription.foreground": "#b5bfe2b2",
+    "peekViewTitleLabel.foreground": "#c6d0f5",
+    "pickerGroup.border": "#ca9ee6",
+    "pickerGroup.foreground": "#ca9ee6",
+    "progressBar.background": "#ca9ee6",
+    "scrollbar.shadow": "#232634",
+    "scrollbarSlider.activeBackground": "#41455966",
+    "scrollbarSlider.background": "#6268807f",
+    "scrollbarSlider.hoverBackground": "#737994",
+    "settings.focusedRowBackground": "#62688033",
+    "settings.headerForeground": "#c6d0f5",
+    "settings.modifiedItemIndicator": "#ca9ee6",
+    "settings.dropdownBackground": "#51576d",
+    "settings.dropdownListBorder": "#00000000",
+    "settings.textInputBackground": "#51576d",
+    "settings.textInputBorder": "#00000000",
+    "settings.numberInputBackground": "#51576d",
+    "settings.numberInputBorder": "#00000000",
+    "sideBar.background": "#292c3c",
+    "sideBar.dropBackground": "#62688099",
+    "sideBar.foreground": "#c6d0f5",
+    "sideBar.border": "#00000000",
+    "sideBarSectionHeader.background": "#292c3c",
+    "sideBarSectionHeader.foreground": "#c6d0f5",
+    "sideBarTitle.foreground": "#ca9ee6",
+    "sideBarTitle.background": "#232634",
+    "statusBar.background": "#232634",
+    "statusBar.foreground": "#c6d0f5",
+    "statusBar.border": "#00000000",
+    "statusBar.noFolderBackground": "#232634",
+    "statusBar.noFolderForeground": "#c6d0f5",
+    "statusBar.debuggingBackground": "#ef9f76",
+    "statusBar.debuggingForeground": "#232634",
+    "statusBarItem.remoteBackground": "#8caaee",
+    "statusBarItem.remoteForeground": "#232634",
+    "statusBarItem.activeBackground": "#62688066",
+    "statusBarItem.hoverBackground": "#62688033",
+    "statusBarItem.prominentForeground": "#ca9ee6",
+    "statusBarItem.prominentBackground": "#00000000",
+    "statusBarItem.prominentHoverBackground": "#62688033",
+    "statusBarItem.errorForeground": "#e78284",
+    "statusBarItem.errorBackground": "#00000000",
+    "statusBarItem.warningForeground": "#ef9f76",
+    "statusBarItem.warningBackground": "#00000000",
+    "commandCenter.foreground": "#b5bfe2",
+    "commandCenter.activeForeground": "#ca9ee6",
+    "commandCenter.background": "#232634",
+    "commandCenter.activeBackground": "#62688033",
+    "commandCenter.border": "#ca9ee6",
+    "tab.activeBackground": "#303446",
+    "tab.activeBorder": "#ca9ee6",
+    "tab.activeBorderTop": "#00000000",
+    "tab.activeForeground": "#ca9ee6",
+    "tab.border": "#292c3c",
+    "tab.inactiveBackground": "#292c3c",
+    "tab.inactiveForeground": "#737994",
+    "terminal.ansiBlack": "#737994",
+    "terminal.ansiBlue": "#8caaee",
+    "terminal.ansiBrightBlack": "#838ba7",
+    "terminal.ansiBrightBlue": "#8caaee",
+    "terminal.ansiBrightCyan": "#99d1db",
+    "terminal.ansiBrightGreen": "#a6d189",
+    "terminal.ansiBrightMagenta": "#f4b8e4",
+    "terminal.ansiBrightRed": "#e78284",
+    "terminal.ansiBrightWhite": "#c6d0f5",
+    "terminal.ansiBrightYellow": "#e5c890",
+    "terminal.ansiCyan": "#99d1db",
+    "terminal.ansiGreen": "#a6d189",
+    "terminal.ansiMagenta": "#f4b8e4",
+    "terminal.ansiRed": "#e78284",
+    "terminal.ansiWhite": "#949cbb",
+    "terminal.ansiYellow": "#e5c890",
+    "terminal.border": "#626880",
+    "terminal.foreground": "#c6d0f5",
+    "terminal.dropBackground": "#62688099",
+    "terminal.selectionBackground": "#626880",
+    "terminalCursor.background": "#303446",
+    "terminalCursor.foreground": "#f2d5cf",
+    "titleBar.activeBackground": "#232634",
+    "titleBar.activeForeground": "#c6d0f5",
+    "titleBar.inactiveBackground": "#232634",
+    "titleBar.inactiveForeground": "#c6d0f57f",
+    "titleBar.border": "#00000000",
+    "welcomePage.tileBackground": "#292c3c",
+    "welcomePage.progress.background": "#232634",
+    "welcomePage.progress.foreground": "#ca9ee6",
+    "walkThrough.embeddedEditorBackground": "#3034464c",
+    "symbolIcon.textForeground": "#c6d0f5",
+    "symbolIcon.arrayForeground": "#ef9f76",
+    "symbolIcon.booleanForeground": "#ca9ee6",
+    "symbolIcon.classForeground": "#e5c890",
+    "symbolIcon.colorForeground": "#f4b8e4",
+    "symbolIcon.constantForeground": "#ef9f76",
+    "symbolIcon.constructorForeground": "#babbf1",
+    "symbolIcon.enumeratorForeground": "#e5c890",
+    "symbolIcon.enumeratorMemberForeground": "#e5c890",
+    "symbolIcon.eventForeground": "#f4b8e4",
+    "symbolIcon.fieldForeground": "#c6d0f5",
+    "symbolIcon.fileForeground": "#ca9ee6",
+    "symbolIcon.folderForeground": "#ca9ee6",
+    "symbolIcon.functionForeground": "#8caaee",
+    "symbolIcon.interfaceForeground": "#e5c890",
+    "symbolIcon.keyForeground": "#81c8be",
+    "symbolIcon.keywordForeground": "#ca9ee6",
+    "symbolIcon.methodForeground": "#8caaee",
+    "symbolIcon.moduleForeground": "#c6d0f5",
+    "symbolIcon.namespaceForeground": "#e5c890",
+    "symbolIcon.nullForeground": "#ea999c",
+    "symbolIcon.numberForeground": "#ef9f76",
+    "symbolIcon.objectForeground": "#e5c890",
+    "symbolIcon.operatorForeground": "#81c8be",
+    "symbolIcon.packageForeground": "#eebebe",
+    "symbolIcon.propertyForeground": "#ea999c",
+    "symbolIcon.referenceForeground": "#e5c890",
+    "symbolIcon.snippetForeground": "#eebebe",
+    "symbolIcon.stringForeground": "#a6d189",
+    "symbolIcon.structForeground": "#81c8be",
+    "symbolIcon.typeParameterForeground": "#ea999c",
+    "symbolIcon.unitForeground": "#c6d0f5",
+    "symbolIcon.variableForeground": "#c6d0f5",
+    "charts.foreground": "#c6d0f5",
+    "charts.lines": "#b5bfe2",
+    "charts.red": "#e78284",
+    "charts.blue": "#8caaee",
+    "charts.yellow": "#e5c890",
+    "charts.orange": "#ef9f76",
+    "charts.green": "#a6d189",
+    "charts.purple": "#ca9ee6",
+    "errorLens.errorBackground": "#e7828426",
+    "errorLens.errorMessageBackground": "#e7828426",
+    "errorLens.errorBackgroundLight": "#e7828426",
+    "errorLens.errorForeground": "#e78284",
+    "errorLens.errorForegroundLight": "#e78284",
+    "errorLens.warningBackground": "#ef9f7626",
+    "errorLens.warningMessageBackground": "#ef9f7626",
+    "errorLens.warningBackgroundLight": "#ef9f7626",
+    "errorLens.warningForeground": "#ef9f76",
+    "errorLens.warningForegroundLight": "#ef9f76",
+    "errorLens.infoBackground": "#8caaee26",
+    "errorLens.infoMessageBackground": "#8caaee26",
+    "errorLens.infoBackgroundLight": "#8caaee26",
+    "errorLens.infoForeground": "#8caaee",
+    "errorLens.infoForegroundLight": "#8caaee",
+    "errorLens.hintBackground": "#a6d18926",
+    "errorLens.hintMessageBackground": "#a6d18926",
+    "errorLens.hintBackgroundLight": "#a6d18926",
+    "errorLens.hintForeground": "#a6d189",
+    "errorLens.hintForegroundLight": "#a6d189",
+    "errorLens.statusBarIconErrorForeground": "#e78284",
+    "errorLens.statusBarIconWarningForeground": "#ef9f76",
+    "errorLens.statusBarErrorForeground": "#e78284",
+    "errorLens.statusBarWarningForeground": "#ef9f76",
+    "errorLens.statusBarInfoForeground": "#8caaee",
+    "errorLens.statusBarHintForeground": "#a6d189",
+    "editorBracketHighlight.foreground1": "#e78284",
+    "editorBracketHighlight.foreground2": "#ef9f76",
+    "editorBracketHighlight.foreground3": "#e5c890",
+    "editorBracketHighlight.foreground4": "#a6d189",
+    "editorBracketHighlight.foreground5": "#85c1dc",
+    "editorBracketHighlight.foreground6": "#ca9ee6",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#ea999c"
+  }
+}

--- a/shiki/shiki-latte-theme.json
+++ b/shiki/shiki-latte-theme.json
@@ -1,0 +1,2798 @@
+{
+  "name": "Catppuccin Latte",
+  "type": "light",
+  "semanticHighlighting": true,
+  "semanticTokenColors": {
+    "enumMember": {
+      "foreground": "#04a5e5"
+    },
+    "variable.constant": {
+      "foreground": "#df8e1d"
+    },
+    "variable.defaultLibrary": {
+      "foreground": "#fe640b"
+    }
+  },
+  "tokenColors": [
+    {
+      "name": "All variable",
+      "scope": ["variable.language", "variable.other"],
+      "settings": {
+        "foreground": "#dd7878"
+      }
+    },
+    {
+      "name": "All function",
+      "scope": ["entity.name.function", "support.function"],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All parameter",
+      "scope": [
+        "variable.parameter.function",
+        "variable.parameter.function-call"
+      ],
+      "settings": {
+        "foreground": "#ea76cb",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All numeric",
+      "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
+      "settings": {
+        "foreground": "#fe640b",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All types",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "All conditionals",
+      "scope": [
+        "keyword.control",
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All punctuation brackets",
+      "scope": [
+        "punctuation.brackets",
+        "punctuation.section",
+        "punctuation.definition"
+      ],
+      "settings": {
+        "foreground": "#8c8fa1"
+      }
+    },
+    {
+      "name": "All punctuation delimiters",
+      "scope": "punctuation.semi",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "All namespace",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#dc8a78"
+      }
+    },
+    {
+      "name": "All operators",
+      "scope": [
+        "keyword.operator.comparison",
+        "keyword.operator.assignment",
+        "keyword.operator.arrow.skinny",
+        "keyword.operator.math",
+        "keyword.operator.key-value",
+        "keyword.operator.misc",
+        "keyword.operator.namespace"
+      ],
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All built-in constants",
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#7287fd",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All constants",
+      "scope": "constant.other",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "JSON quoted string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "JSON punctuation string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "JSON punct structure",
+      "scope": [
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json",
+        "source.json meta.structure.array.json > value.json > string.quoted.json",
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation",
+        "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+      ],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "JSON property name",
+      "scope": "support.type.property-name.json.comments",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "JSON constants",
+      "scope": "constant.language.json.comments",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "JSON punctuation",
+      "scope": [
+        "punctuation.separator.dictionary.pair.json.comments",
+        "punctuation.separator.array.json.comments"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "JSON brackets",
+      "scope": [
+        "punctuation.definition.dictionary.begin.json.comments",
+        "punctuation.definition.dictionary.end.json.comments",
+        "punctuation.definition.array.begin.json.comments",
+        "punctuation.definition.array.end.json.comments"
+      ],
+      "settings": {
+        "foreground": "#7c7f93"
+      }
+    },
+    {
+      "name": "JSON constant language",
+      "scope": [
+        "source.json meta.structure.dictionary.json > constant.language.json",
+        "source.json meta.structure.array.json > constant.language.json"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "JSON property name [VSCODE-CUSTOM]",
+      "scope": "support.type.property-name.json",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "unison punctuation",
+      "scope": [
+        "punctuation.definition.delayed.unison",
+        "punctuation.definition.list.begin.unison",
+        "punctuation.definition.list.end.unison",
+        "punctuation.definition.ability.begin.unison",
+        "punctuation.definition.ability.end.unison",
+        "punctuation.operator.assignment.as.unison",
+        "punctuation.separator.pipe.unison",
+        "punctuation.separator.delimiter.unison",
+        "punctuation.definition.hash.unison"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "haskell variable generic-type",
+      "scope": "variable.other.generic-type.haskell",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "haskell storage type",
+      "scope": "storage.type.haskell",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "support.variable.magic.python",
+      "scope": "support.variable.magic.python",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "punctuation.separator.parameters.python",
+      "scope": [
+        "punctuation.separator.period.python",
+        "punctuation.separator.element.python",
+        "punctuation.parenthesis.begin.python",
+        "punctuation.parenthesis.end.python"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.self.python",
+      "scope": "variable.parameter.function.language.special.self.python",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Rust modifier",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Rust types",
+      "scope": "entity.name.type.rust",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Rust functions std",
+      "scope": "support.function.std.rust",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Rust functions",
+      "scope": "entity.name.function.rust",
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust function keyword",
+      "scope": "keyword.other.fn.rust",
+      "settings": {
+        "foreground": "#e64553"
+      }
+    },
+    {
+      "name": "Rust conditionals",
+      "scope": "keyword.control.rust",
+      "settings": {
+        "foreground": "#8839ef",
+        "fontStyle": "bold italic"
+      }
+    },
+    {
+      "name": "Rust punctuation brackets",
+      "scope": [
+        "punctuation.brackets.curly.rust",
+        "punctuation.brackets.round.rust",
+        "punctuation.brackets.square.rust",
+        "punctuation.brackets.attribute.rust"
+      ],
+      "settings": {
+        "foreground": "#8c8fa1"
+      }
+    },
+    {
+      "name": "Rust namespace",
+      "scope": "entity.name.namespace.rust",
+      "settings": {
+        "foreground": "#dc8a78"
+      }
+    },
+    {
+      "name": "Rust punctuation delimiters",
+      "scope": "punctuation.semi.rust",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Rust operators",
+      "scope": [
+        "keyword.operator.comparison.rust",
+        "keyword.operator.assignment.equal.rust",
+        "keyword.operator.arrow.skinny.rust",
+        "keyword.operator.math.rust",
+        "keyword.operator.key-value.rust",
+        "keyword.operator.misc.rust"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Rust operator namespaces",
+      "scope": "keyword.operator.namespace.rust",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Rust definition attributes",
+      "scope": [
+        "punctuation.definition.attribute.rust",
+        "keyword.operator.attribute.inner.rust"
+      ],
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Rust math logic",
+      "scope": "constant.numeric.decimal.rust",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Rust constants",
+      "scope": "support.constant.core.rust",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Rust entity name",
+      "scope": "entity.name.lifetime.rust",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Rust variable",
+      "scope": ["variable.language.rust", "variable.other.rust"],
+      "settings": {
+        "foreground": "#4c4f69",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust misc operators",
+      "scope": "keyword.operator.misc.rust",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Rust sigil operator",
+      "scope": "keyword.operator.sigil.rust",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Lua operators",
+      "scope": "keyword.operator.lua",
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua numeric",
+      "scope": "constant.numeric.integer.lua",
+      "settings": {
+        "foreground": "#fe640b",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua other vars",
+      "scope": "variable.other.lua",
+      "settings": {
+        "foreground": "#7287fd",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Lua brackets",
+      "scope": [
+        "punctuation.definition.parameters.end.lua",
+        "punctuation.definition.parameters.begin.lua"
+      ],
+      "settings": {
+        "foreground": "#8c8fa1"
+      }
+    },
+    {
+      "name": "C++ Punct Delimiters",
+      "scope": "punctuation.terminator.statement.cpp",
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ Variables",
+      "scope": "variable.other.local.cpp",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "C++ Operators",
+      "scope": [
+        "punctuation.separator.scope-resolution.cpp",
+        "punctuation.separator.scope-resolution.namespace.alias.cpp",
+        "punctuation.separator.scope-resolution.namespace.using.cpp"
+      ],
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ function",
+      "scope": "meta.function.c,meta.function.cpp",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "C++ constructor/destructor",
+      "scope": [
+        "entity.name.function.definition.special.constructor",
+        "entity.name.function.definition.special.member.destructor"
+      ],
+      "settings": {
+        "foreground": "#7287fd"
+      }
+    },
+    {
+      "name": "C++ directive",
+      "scope": [
+        "keyword.control.directive",
+        "keyword.other.using.directive",
+        "punctuation.definition.directive"
+      ],
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ ifdef directive",
+      "scope": [
+        "keyword.control.directive.conditional.ifdef.cpp",
+        "keyword.control.directive.else.cpp",
+        "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp",
+        "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "C++ misc",
+      "scope": [
+        "entity.name.other.preprocessor.macro.predefined.probably",
+        "entity.name.scope-resolution.cpp"
+      ],
+      "settings": {
+        "foreground": "#dc8a78",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ pointer/reference",
+      "scope": [
+        "storage.modifier.pointer.cpp",
+        "storage.modifier.reference.cpp"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "C++ loop/conditional",
+      "scope": [
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#8839ef",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ return",
+      "scope": "keyword.control.return",
+      "settings": {
+        "foreground": "#ea76cb"
+      }
+    },
+    {
+      "name": "C++ block",
+      "scope": [
+        "punctuation.section.block.begin.bracket.curly.cpp",
+        "punctuation.section.block.end.bracket.curly.cpp",
+        "punctuation.terminator.statement.c",
+        "punctuation.section.block.begin.bracket.curly.c",
+        "punctuation.section.block.end.bracket.curly.c",
+        "punctuation.section.parens.begin.bracket.round.c",
+        "punctuation.section.parens.end.bracket.round.c",
+        "punctuation.section.parameters.begin.bracket.round.c",
+        "punctuation.section.parameters.end.bracket.round.c"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "C++ storage type modifier",
+      "scope": "storage.type.built-in.primitive.cpp",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "C++/C#",
+      "scope": [
+        "entity.name.label.cs",
+        "entity.name.scope-resolution.function.call",
+        "entity.name.scope-resolution.function.definition"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "support.constant.edge",
+      "scope": "support.constant.edge",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "regexp constant character-class",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "regexp operator.quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "punctuation.definition",
+      "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": "comment markup.link",
+      "settings": {
+        "foreground": "#9ca0b0"
+      }
+    },
+    {
+      "name": "markup diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "diff",
+      "scope": [
+        "meta.diff.header.from-file",
+        "meta.diff.header.to-file",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.to-file.diff"
+      ],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "inserted.diff",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "deleted.diff",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Quote multi",
+      "scope": [
+        "string.quoted.docstring.multi",
+        "string.quoted.multi",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.end.python",
+        "markup.fenced_code.block"
+      ],
+      "settings": {
+        "foreground": "#40a02b",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "js/ts punctuation separator key-value",
+      "scope": "punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "js/ts import keyword",
+      "scope": "keyword.operator.expression.import",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "math js/ts",
+      "scope": "support.constant.math",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "math property js/ts",
+      "scope": "support.constant.property.math",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "js/ts variable.other.constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "java type",
+      "scope": [
+        "storage.type.annotation.java",
+        "storage.type.object.array.java"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "java source",
+      "scope": "source.java",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": [
+        "punctuation.section.block.begin.java",
+        "punctuation.section.block.end.java",
+        "punctuation.definition.method-parameters.begin.java",
+        "punctuation.definition.method-parameters.end.java",
+        "meta.method.identifier.java",
+        "punctuation.section.method.begin.java",
+        "punctuation.section.method.end.java",
+        "punctuation.terminator.java",
+        "punctuation.section.class.begin.java",
+        "punctuation.section.class.end.java",
+        "punctuation.section.inner-class.begin.java",
+        "punctuation.section.inner-class.end.java",
+        "meta.method-call.java",
+        "punctuation.section.class.begin.bracket.curly.java",
+        "punctuation.section.class.end.bracket.curly.java",
+        "punctuation.section.method.begin.bracket.curly.java",
+        "punctuation.section.method.end.bracket.curly.java",
+        "punctuation.separator.period.java",
+        "punctuation.bracket.angle.java",
+        "punctuation.definition.annotation.java",
+        "meta.method.body.java"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "meta.method.java",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "java variable.name",
+      "scope": "meta.definition.variable.name.java",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "operator logical",
+      "scope": ["keyword.operator.logical", "keyword.operator.ternary"],
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "operator bitwise",
+      "scope": "keyword.operator.bitwise",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "support.constant.property-value.scss",
+      "scope": [
+        "support.constant.property-value.scss",
+        "support.constant.property-value.css"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": [
+        "keyword.operator.css",
+        "keyword.operator.scss",
+        "keyword.operator.less"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "css color standard name",
+      "scope": [
+        "support.constant.color.w3c-standard-color-name.css",
+        "support.constant.color.w3c-standard-color-name.scss"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "css comma",
+      "scope": "punctuation.separator.list.comma.css",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "css attribute-name.id",
+      "scope": "support.constant.color.w3c-standard-color-name.css",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "css property-name",
+      "scope": "support.type.vendored.property-name.css",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "js/ts module",
+      "scope": [
+        "support.module.node",
+        "support.type.object.module",
+        "support.module.node"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "entity.name.type.module",
+      "scope": "entity.name.type.module",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "js variable readwrite",
+      "scope": [
+        "variable.other.readwrite",
+        "meta.object-literal.key",
+        "support.variable.property",
+        "support.variable.object.process",
+        "support.variable.object.node"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "js/ts json",
+      "scope": "support.constant.json",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "js/ts Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.ternary",
+        "keyword.operator.optional",
+        "keyword.operator.expression.keyof"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "js/ts console",
+      "scope": "support.type.object.console",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "js/ts support.variable.property.process",
+      "scope": "support.variable.property.process",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "js console function",
+      "scope": "entity.name.function,support.function.console",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "operator",
+      "scope": "keyword.operator.delete",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "js dom",
+      "scope": "support.type.object.dom",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "js dom variable",
+      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": [
+        "keyword.operator.arithmetic",
+        "keyword.operator.comparison",
+        "keyword.operator.decrement",
+        "keyword.operator.increment",
+        "keyword.operator.relational"
+      ],
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C operators",
+      "scope": [
+        "keyword.operator.c",
+        "keyword.operator.increment.c",
+        "keyword.operator.decrement.c",
+        "keyword.operator.bitwise.shift.c",
+        "keyword.operator.cpp",
+        "keyword.operator.increment.cpp",
+        "keyword.operator.decrement.cpp",
+        "keyword.operator.bitwise.shift.cpp"
+      ],
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Other punctuation .c",
+      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "C type posix-reserved",
+      "scope": [
+        "support.type.posix-reserved.c",
+        "support.type.posix-reserved.cpp"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "keyword.operator.sizeof.c",
+      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "python type",
+      "scope": "support.type.python",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "python block",
+      "scope": [
+        "punctuation.definition.arguments.begin.python",
+        "punctuation.definition.arguments.end.python",
+        "punctuation.separator.arguments.python",
+        "punctuation.definition.list.begin.python",
+        "punctuation.definition.list.end.python"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "python function-call.generic",
+      "scope": "meta.function-call.generic.python",
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#04a5e5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Java Variables",
+      "scope": "token.variable.parameter.java",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Java Imports",
+      "scope": "import.storage.java",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package.keyword",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Functions",
+      "scope": [
+        "entity.name.function",
+        "meta.require",
+        "support.function.any-method",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#1e66f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "entity.name.type.namespace",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "support.class, entity.name.type.class",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": "entity.name.class.identifier.namespace.type",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "variable.other.class.js",
+        "variable.other.class.ts"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Class name php",
+      "scope": "variable.other.class.php",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Type Name",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Control Elements",
+      "scope": "control.elements, keyword.operator.less",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Methods",
+      "scope": "keyword.other.special-method",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Storage JS TS",
+      "scope": "token.storage",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete, In, Of, Instanceof, New, Typeof, Void",
+      "scope": [
+        "keyword.operator.expression.delete",
+        "keyword.operator.expression.in",
+        "keyword.operator.expression.of",
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.expression.typeof",
+        "keyword.operator.expression.void"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Java Storage",
+      "scope": "token.storage.type.java",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Support",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.property-value",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.font-name",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Meta tag",
+      "scope": "meta.tag",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": "string",
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "Inherited Class",
+      "scope": "entity.other.inherited-class",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Constant other symbol",
+      "scope": "constant.other.symbol",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Integers",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "constant",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "punctuation.definition.constant",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Tags",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Attributes",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Attribute IDs",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Attribute class",
+      "scope": "entity.other.attribute-name.class.css",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "SCSS variables",
+      "scope": "variable.scss",
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Selector",
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Units",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "markup.bold,todo.bold",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "punctuation.definition.bold",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "markup Italic",
+      "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "emphasis md",
+      "scope": "emphasis md",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "punctuation.definition.list.begin.markdown",
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "punctuation.definition.list.markdown",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "beginning.punctuation.definition.list.markdown",
+      "scope": ["beginning.punctuation.definition.list.markdown"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Regular Expressions",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Escape Characters",
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded, variable.interpolation",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "illegal, deprecated",
+      "scope": "invalid.illegal, invalid.deprecated",
+      "settings": {
+        "foreground": "#9ca0b0",
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal.bad-ampersand.html",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Broken",
+      "scope": "invalid.broken",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Unimplemented",
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "foreground": "#6c6f85"
+      }
+    },
+    {
+      "name": "laravel blade tag",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "laravel blade @",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "use statement for other classes",
+      "scope": [
+        "support.other.namespace.use.php",
+        "support.other.namespace.use-as.php",
+        "support.other.namespace.php",
+        "entity.other.alias.php",
+        "meta.interface.php"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "error suppression",
+      "scope": "keyword.operator.error-control.php",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "php instanceof",
+      "scope": "keyword.operator.type.php",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "style double quoted array index normal begin",
+      "scope": "punctuation.section.array.begin.php",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "style double quoted array index normal end",
+      "scope": "punctuation.section.array.end.php",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "php illegal.non-null-typehinted",
+      "scope": "invalid.illegal.non-null-typehinted.php",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "php types",
+      "scope": [
+        "storage.type.php",
+        "meta.other.type.phpdoc.php",
+        "keyword.other.type.php",
+        "keyword.other.array.phpdoc.php"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "php call-function",
+      "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "php function-resets",
+      "scope": [
+        "punctuation.definition.parameters.begin.bracket.round.php",
+        "punctuation.definition.parameters.end.bracket.round.php",
+        "punctuation.separator.delimiter.php",
+        "punctuation.section.scope.begin.php",
+        "punctuation.section.scope.end.php",
+        "punctuation.terminator.expression.php",
+        "punctuation.definition.arguments.begin.bracket.round.php",
+        "punctuation.definition.arguments.end.bracket.round.php",
+        "punctuation.definition.storage-type.begin.bracket.round.php",
+        "punctuation.definition.storage-type.end.bracket.round.php",
+        "punctuation.definition.array.begin.bracket.round.php",
+        "punctuation.definition.array.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.round.php",
+        "punctuation.definition.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.curly.php",
+        "punctuation.definition.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.start.bracket.curly.php",
+        "punctuation.definition.section.switch-block.begin.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php"
+      ],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": [
+        "support.constant.ext.php",
+        "support.constant.std.php",
+        "support.constant.core.php",
+        "support.constant.parser-token.php"
+      ],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "php goto",
+      "scope": "entity.name.goto-label.php,support.other.php",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "php logical/bitwise operator",
+      "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "php regexp operator",
+      "scope": "keyword.operator.regexp.php",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "php comparison",
+      "scope": "keyword.operator.comparison.php",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "php heredoc/nowdoc",
+      "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "python function decorator @",
+      "scope": "meta.function.decorator.python",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": [
+        "support.token.decorator.python",
+        "meta.function.decorator.identifier.python"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "parameter function js/ts",
+      "scope": "function.parameter",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "brace function",
+      "scope": "function.brace",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "parameter function ruby cs",
+      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "constant.language.symbol.ruby",
+      "scope": "constant.language.symbol.ruby",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "rgb-value",
+      "scope": "rgb-value",
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "rgb value",
+      "scope": "inline-color-decoration rgb-value",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "rgb value less",
+      "scope": "less rgb-value",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "sass selector",
+      "scope": "selector.sass",
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "ts primitive/builtin types",
+      "scope": [
+        "support.type.primitive.ts",
+        "support.type.builtin.ts",
+        "support.type.primitive.tsx",
+        "support.type.builtin.tsx"
+      ],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "block scope",
+      "scope": "block.scope.end,block.scope.begin",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "cs storage type",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "cs local variable",
+      "scope": "entity.name.variable.local.cs",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": ["meta.template.expression"],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Import module JS",
+      "scope": ["keyword.operator.module"],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "js Flowtype",
+      "scope": ["support.type.type.flowtype"],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "js Flow",
+      "scope": ["support.type.primitive"],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "js class prop",
+      "scope": ["meta.property.object"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "js func parameter",
+      "scope": ["variable.parameter.function.js"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "js template literals begin",
+      "scope": ["keyword.other.template.begin"],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "js template literals end",
+      "scope": ["keyword.other.template.end"],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "js template literals variable braces begin",
+      "scope": ["keyword.other.substitution.begin"],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "js template literals variable braces end",
+      "scope": ["keyword.other.substitution.end"],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.arithmetic.go",
+        "keyword.operator.address.go"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "Go package name",
+      "scope": ["entity.name.package.go"],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Go import statement",
+      "scope": "keyword.import.go",
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "elm prelude",
+      "scope": ["support.type.prelude.elm"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "elm constant",
+      "scope": ["support.constant.elm"],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": ["punctuation.quasi.element"],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": ["constant.character.entity"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+      "scope": [
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.pseudo-class"
+      ],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": ["entity.global.clojure"],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": ["meta.symbol.clojure"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": ["constant.keyword.clojure"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": ["source.ini"],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "Shell definition variables",
+      "scope": ["punctuation.definition.variable.shell"],
+      "settings": {
+        "foreground": "#8c8fa1"
+      }
+    },
+    {
+      "name": "Shell logical operators",
+      "scope": ["keyword.operator.logical.shell"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Shell clauses",
+      "scope": ["meta.scope.case-clause-body.shell"],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Shell funcs",
+      "scope": ["meta.scope.group.shell"],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Shell interpolated cmds",
+      "scope": ["string.interpolated.dollar.shell"],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "Shell interpolated strings",
+      "scope": ["string.quoted.single.shell"],
+      "settings": {
+        "foreground": "#7287fd"
+      }
+    },
+    {
+      "name": "Shell pipe symbol",
+      "scope": ["keyword.operator.pipe.shell"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "Shell group definition",
+      "scope": ["punctuation.definition.group.shell"],
+      "settings": {
+        "foreground": "#8c8fa1"
+      }
+    },
+    {
+      "name": "Shell conditionals",
+      "scope": ["keyword.control.shell"],
+      "settings": {
+        "foreground": "#8839ef"
+      }
+    },
+    {
+      "name": "Shell operators and punct delimiters",
+      "scope": ["keyword.operator.list.shell"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Shell parenthesis",
+      "scope": ["punctuation.definition.logical-expression.shell"],
+      "settings": {
+        "foreground": "#8c8fa1"
+      }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": ["meta.scope.prerequisites.makefile"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": ["source.makefile"],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": ["storage.modifier.import.groovy"],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": ["meta.method.groovy"],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": ["meta.definition.variable.name.groovy"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": ["meta.definition.class.inherited.classes.groovy"],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": ["support.variable.semantic.hlsl"],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "SQL Variables",
+      "scope": ["text.variable", "text.bracketed"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "types",
+      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "settings": {
+        "foreground": "#fe640b"
+      }
+    },
+    {
+      "name": "heading 1, keyword",
+      "scope": ["entity.name.function.xi"],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "heading 2, callable",
+      "scope": ["entity.name.class.xi"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "heading 3, property",
+      "scope": ["constant.character.character-class.regexp.xi"],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "heading 4, type, class, interface",
+      "scope": ["constant.regexp.xi"],
+      "settings": {
+        "foreground": "#d20f39"
+      }
+    },
+    {
+      "name": "heading 5, enums, preprocessor, constant, decorator",
+      "scope": ["keyword.control.xi"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "heading 6, number",
+      "scope": ["invalid.xi"],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "string",
+      "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+      "settings": {
+        "foreground": "#40a02b"
+      }
+    },
+    {
+      "name": "comments",
+      "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+      "settings": {
+        "foreground": "#9ca0b0"
+      }
+    },
+    {
+      "name": "link",
+      "scope": ["constant.character.xi"],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "accent",
+      "scope": ["accent.xi"],
+      "settings": {
+        "foreground": "#1e66f5"
+      }
+    },
+    {
+      "name": "wikiword",
+      "scope": ["wikiword.xi"],
+      "settings": {
+        "foreground": "#df8e1d"
+      }
+    },
+    {
+      "name": "language operators like '+', '-' etc",
+      "scope": ["constant.other.color.rgb-value.xi"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "elements to dim",
+      "scope": ["punctuation.definition.tag.xi"],
+      "settings": {
+        "foreground": "#9ca0b0"
+      }
+    },
+    {
+      "name": "Markdown underscore-style headers",
+      "scope": [
+        "entity.name.label.cs",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.setext.2.markdown"
+      ],
+      "settings": {
+        "foreground": "#179299"
+      }
+    },
+    {
+      "name": "meta.brace.square",
+      "scope": [" meta.brace.square"],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": "comment, punctuation.definition.comment",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#9ca0b0"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": {
+        "foreground": "#9ca0b0"
+      }
+    },
+    {
+      "name": "punctuation.definition.block.sequence.item.yaml",
+      "scope": "punctuation.definition.block.sequence.item.yaml",
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "scope": ["constant.language.symbol.elixir"],
+      "settings": {
+        "foreground": "#04a5e5"
+      }
+    },
+    {
+      "name": "js/ts italic",
+      "scope": [
+        "entity.other.attribute-name.js",
+        "entity.other.attribute-name.ts",
+        "entity.other.attribute-name.jsx",
+        "entity.other.attribute-name.tsx",
+        "variable.parameter",
+        "variable.language.super"
+      ],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "comment",
+      "scope": "comment.line.double-slash,comment.block.documentation",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword import",
+      "scope": "keyword.control.import.python",
+      "settings": {
+        "foreground": "#179299",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword flow",
+      "scope": "keyword.control.flow.python",
+      "settings": {
+        "foreground": "#8839ef",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "python storage type",
+      "scope": "storage.type.function.python",
+      "settings": {
+        "foreground": "#e64553",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "markup.italic.markdown",
+      "scope": "markup.italic.markdown",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "invalid.deprecated.line-too-long.git-commit",
+      "scope": "invalid.deprecated.line-too-long.git-commit",
+      "settings": {
+        "foreground": "#df8e1d",
+        "fontStyle": "underline"
+      }
+    }
+  ],
+  "colors": {
+    "focusBorder": "#00000000",
+    "foreground": "#4c4f69",
+    "disabledForeground": "#6c6f85",
+    "widget.shadow": "#e6e9ef7f",
+    "selection.background": "#acb0be",
+    "descriptionForeground": "#4c4f69",
+    "errorForeground": "#d20f39",
+    "icon.foreground": "#8839ef",
+    "sash.hoverBorder": "#8839ef",
+    "window.activeBorder": "#00000000",
+    "window.inactiveBorder": "#00000000",
+    "textBlockQuote.background": "#e6e9ef",
+    "textBlockQuote.border": "#dce0e8",
+    "textCodeBlock.background": "#eff1f5",
+    "textLink.activeForeground": "#04a5e5",
+    "textLink.foreground": "#1e66f5",
+    "textPreformat.foreground": "#4c4f69",
+    "textSeparator.foreground": "#8839ef",
+    "activityBar.background": "#dce0e8",
+    "activityBar.foreground": "#8839ef",
+    "activityBar.dropBar": "#acb0be99",
+    "activityBar.inactiveForeground": "#9ca0b0",
+    "activityBar.border": "#00000000",
+    "activityBarBadge.background": "#8839ef",
+    "activityBarBadge.foreground": "#dce0e8",
+    "activityBar.activeBorder": "#00000000",
+    "activityBar.activeBackground": "#00000000",
+    "activityBar.activeFocusBorder": "#00000000",
+    "badge.background": "#bcc0cc",
+    "badge.foreground": "#4c4f69",
+    "breadcrumb.activeSelectionForeground": "#8839ef",
+    "breadcrumb.background": "#e6e9ef",
+    "breadcrumb.focusForeground": "#8839ef",
+    "breadcrumb.foreground": "#4c4f69cc",
+    "breadcrumbPicker.background": "#e6e9ef",
+    "button.background": "#8839ef",
+    "button.foreground": "#dce0e8",
+    "button.border": "#00000000",
+    "button.separator": "#00000000",
+    "button.hoverBackground": "#9c4dff",
+    "button.secondaryForeground": "#4c4f69",
+    "button.secondaryBackground": "#acb0be",
+    "button.secondaryHoverBackground": "#c0c4d2",
+    "checkbox.background": "#bcc0cc",
+    "checkbox.border": "#00000000",
+    "checkbox.foreground": "#8839ef",
+    "dropdown.background": "#e6e9ef",
+    "dropdown.listBackground": "#acb0be",
+    "dropdown.border": "#8839ef",
+    "dropdown.foreground": "#4c4f69",
+    "debugToolBar.background": "#dce0e8",
+    "debugToolBar.border": "#00000000",
+    "debugExceptionWidget.background": "#dce0e8",
+    "debugExceptionWidget.border": "#8839ef",
+    "debugTokenExpression.number": "#fe640b",
+    "debugTokenExpression.boolean": "#8839ef",
+    "debugTokenExpression.string": "#40a02b",
+    "debugTokenExpression.error": "#d20f39",
+    "debugIcon.breakpointForeground": "#d20f39",
+    "debugIcon.breakpointDisabledForeground": "#d20f3999",
+    "debugIcon.breakpointUnverifiedForeground": "#eff1f5",
+    "debugIcon.breakpointCurrentStackframeForeground": "#acb0be",
+    "debugIcon.breakpointStackframeForeground": "#acb0be",
+    "debugIcon.startForeground": "#40a02b",
+    "debugIcon.pauseForeground": "#1e66f5",
+    "debugIcon.stopForeground": "#d20f39",
+    "debugIcon.disconnectForeground": "#acb0be",
+    "debugIcon.restartForeground": "#179299",
+    "debugIcon.stepOverForeground": "#8839ef",
+    "debugIcon.stepIntoForeground": "#4c4f69",
+    "debugIcon.stepOutForeground": "#4c4f69",
+    "debugIcon.continueForeground": "#40a02b",
+    "debugIcon.stepBackForeground": "#acb0be",
+    "debugConsole.infoForeground": "#1e66f5",
+    "debugConsole.warningForeground": "#fe640b",
+    "debugConsole.errorForeground": "#d20f39",
+    "debugConsole.sourceForeground": "#dc8a78",
+    "debugConsoleInputIcon.foreground": "#4c4f69",
+    "diffEditor.border": "#acb0be",
+    "diffEditor.insertedTextBackground": "#40a02b19",
+    "diffEditor.removedTextBackground": "#d20f3919",
+    "diffEditor.insertedLineBackground": "#40a02b26",
+    "diffEditor.removedLineBackground": "#d20f3926",
+    "diffEditor.diagonalFill": "#acb0be99",
+    "diffEditorOverview.insertedForeground": "#40a02bcc",
+    "diffEditorOverview.removedForeground": "#d20f39cc",
+    "editor.background": "#eff1f5",
+    "editor.findMatchBackground": "#acb0be",
+    "editor.findMatchBorder": "#8839ef66",
+    "editor.findMatchHighlightBackground": "#fe640b59",
+    "editor.findMatchHighlightBorder": "#00000000",
+    "editor.findRangeHighlightBackground": "#acb0be4c",
+    "editor.findRangeHighlightBorder": "#00000000",
+    "editor.foldBackground": "#04a5e53f",
+    "editor.foreground": "#4c4f69",
+    "editor.hoverHighlightBackground": "#04a5e53f",
+    "editor.inactiveSelectionBackground": "#00000000",
+    "editor.lineHighlightBackground": "#4c4f6911",
+    "editor.lineHighlightBorder": "#eff1f5",
+    "editor.rangeHighlightBackground": "#04a5e53f",
+    "editor.rangeHighlightBorder": "#00000000",
+    "editor.selectionBackground": "#acb0be",
+    "editor.selectionHighlightBackground": "#7c7f9366",
+    "editor.selectionHighlightBorder": "#04a5e533",
+    "editor.wordHighlightBackground": "#acb0beb2",
+    "editor.wordHighlightStrongBackground": "#acb0be7f",
+    "editorBracketMatch.background": "#7c7f9319",
+    "editorBracketMatch.border": "#7c7f93",
+    "editorCodeLens.foreground": "#8c8fa1",
+    "editorCursor.background": "#eff1f5",
+    "editorCursor.foreground": "#dc8a78",
+    "editorError.background": "#00000000",
+    "editorError.border": "#00000000",
+    "editorError.foreground": "#d20f39",
+    "editorGroup.border": "#acb0be",
+    "editorGroup.dropBackground": "#acb0be99",
+    "editorGroup.emptyBackground": "#eff1f5",
+    "editorGroupHeader.tabsBackground": "#dce0e8",
+    "editorGutter.addedBackground": "#40a02b",
+    "editorGutter.background": "#eff1f5",
+    "editorGutter.commentRangeForeground": "#7c7f93",
+    "editorGutter.deletedBackground": "#d20f39",
+    "editorGutter.foldingControlForeground": "#7c7f93",
+    "editorGutter.modifiedBackground": "#04a5e5",
+    "editorHoverWidget.background": "#e6e9ef",
+    "editorHoverWidget.border": "#acb0be",
+    "editorHoverWidget.foreground": "#4c4f69",
+    "editorIndentGuide.activeBackground": "#acb0be",
+    "editorIndentGuide.background": "#bcc0cc",
+    "editorInfo.background": "#00000000",
+    "editorInfo.border": "#00000000",
+    "editorInfo.foreground": "#1e66f5",
+    "editorInlayHint.foreground": "#acb0be",
+    "editorInlayHint.background": "#e6e9efbf",
+    "editorInlayHint.typeForeground": "#5c5f77",
+    "editorInlayHint.typeBackground": "#e6e9efbf",
+    "editorInlayHint.parameterForeground": "#6c6f85",
+    "editorInlayHint.parameterBackground": "#e6e9efbf",
+    "editorLineNumber.activeForeground": "#8839ef",
+    "editorLineNumber.foreground": "#8c8fa1",
+    "editorLink.activeForeground": "#8839ef",
+    "editorMarkerNavigation.background": "#e6e9ef",
+    "editorMarkerNavigationError.background": "#d20f39",
+    "editorMarkerNavigationInfo.background": "#1e66f5",
+    "editorMarkerNavigationWarning.background": "#df8e1d",
+    "editorOverviewRuler.background": "#e6e9ef",
+    "editorOverviewRuler.border": "#4c4f6911",
+    "editorRuler.foreground": "#acb0be",
+    "editor.stackFrameHighlightBackground": "#df8e1d26",
+    "editor.focusedStackFrameHighlightBackground": "#40a02b26",
+    "editorStickyScrollHover.background": "#ccd0da",
+    "editorSuggestWidget.background": "#e6e9ef",
+    "editorSuggestWidget.border": "#acb0be",
+    "editorSuggestWidget.foreground": "#4c4f69",
+    "editorSuggestWidget.highlightForeground": "#8839ef",
+    "editorSuggestWidget.selectedBackground": "#ccd0da",
+    "editorWarning.background": "#00000000",
+    "editorWarning.border": "#00000000",
+    "editorWarning.foreground": "#fe640b",
+    "editorWhitespace.foreground": "#7c7f9366",
+    "editorWidget.background": "#e6e9ef",
+    "editorWidget.foreground": "#4c4f69",
+    "editorWidget.resizeBorder": "#acb0be",
+    "editorLightBulb.foreground": "#df8e1d",
+    "extensionButton.prominentForeground": "#dce0e8",
+    "extensionButton.prominentBackground": "#8839ef",
+    "extensionButton.prominentHoverBackground": "#9c4dff",
+    "extensionBadge.remoteBackground": "#1e66f5",
+    "extensionBadge.remoteForeground": "#dce0e8",
+    "extensionIcon.starForeground": "#df8e1d",
+    "extensionIcon.verifiedForeground": "#40a02b",
+    "extensionIcon.preReleaseForeground": "#dc8a78",
+    "extensionIcon.sponsorForeground": "#ea76cb",
+    "gitDecoration.addedResourceForeground": "#40a02b",
+    "gitDecoration.conflictingResourceForeground": "#8839ef",
+    "gitDecoration.deletedResourceForeground": "#d20f39",
+    "gitDecoration.ignoredResourceForeground": "#9ca0b0",
+    "gitDecoration.modifiedResourceForeground": "#df8e1d",
+    "gitDecoration.stageDeletedResourceForeground": "#d20f39",
+    "gitDecoration.stageModifiedResourceForeground": "#df8e1d",
+    "gitDecoration.submoduleResourceForeground": "#1e66f5",
+    "gitDecoration.untrackedResourceForeground": "#40a02b",
+    "input.background": "#ccd0da",
+    "input.border": "#00000000",
+    "input.foreground": "#4c4f69",
+    "input.placeholderForeground": "#4c4f6972",
+    "inputOption.activeBackground": "#1e66f526",
+    "inputOption.activeBorder": "#dce0e833",
+    "inputOption.activeForeground": "#4c4f69",
+    "inputValidation.errorBackground": "#d20f39",
+    "inputValidation.errorBorder": "#dce0e833",
+    "inputValidation.errorForeground": "#dce0e8",
+    "inputValidation.infoBackground": "#1e66f5",
+    "inputValidation.infoBorder": "#dce0e833",
+    "inputValidation.infoForeground": "#dce0e8",
+    "inputValidation.warningBackground": "#fe640b",
+    "inputValidation.warningBorder": "#dce0e833",
+    "inputValidation.warningForeground": "#dce0e8",
+    "list.activeSelectionBackground": "#bcc0cc",
+    "list.activeSelectionForeground": "#4c4f69",
+    "list.dropBackground": "#acb0be99",
+    "list.focusBackground": "#ccd0da",
+    "list.focusForeground": "#4c4f69",
+    "list.focusOutline": "#00000000",
+    "list.highlightForeground": "#8839ef",
+    "list.hoverBackground": "#acb0be",
+    "list.hoverForeground": "#4c4f69",
+    "list.inactiveSelectionBackground": "#bcc0cc",
+    "list.inactiveSelectionForeground": "#4c4f69",
+    "list.warningForeground": "#df8e1d",
+    "listFilterWidget.background": "#bcc0cc",
+    "listFilterWidget.noMatchesOutline": "#d20f39",
+    "listFilterWidget.outline": "#00000000",
+    "tree.indentGuidesStroke": "#9ca0b0",
+    "menu.background": "#eff1f5",
+    "menu.border": "#eff1f57f",
+    "menu.foreground": "#4c4f69",
+    "menu.selectionBackground": "#acb0be",
+    "menu.selectionBorder": "#00000000",
+    "menu.selectionForeground": "#4c4f69",
+    "menu.separatorBackground": "#acb0be",
+    "menubar.selectionBackground": "#bcc0cc",
+    "menubar.selectionForeground": "#4c4f69",
+    "merge.commonContentBackground": "#bcc0cc",
+    "merge.commonHeaderBackground": "#acb0be",
+    "merge.currentContentBackground": "#40a02b33",
+    "merge.currentHeaderBackground": "#40a02b66",
+    "merge.incomingContentBackground": "#1e66f533",
+    "merge.incomingHeaderBackground": "#1e66f566",
+    "minimap.background": "#e6e9ef7f",
+    "minimap.errorHighlight": "#d20f39",
+    "minimap.findMatchHighlight": "#acb0be",
+    "minimap.selectionHighlight": "#acb0be",
+    "minimap.warningHighlight": "#df8e1d",
+    "minimapGutter.addedBackground": "#40a02b",
+    "minimapGutter.deletedBackground": "#d20f39",
+    "minimapGutter.modifiedBackground": "#04a5e5",
+    "notificationCenter.border": "#8839ef",
+    "notificationCenterHeader.foreground": "#4c4f69",
+    "notificationCenterHeader.background": "#e6e9ef",
+    "notificationToast.border": "#8839ef",
+    "notifications.foreground": "#4c4f69",
+    "notifications.background": "#e6e9ef",
+    "notifications.border": "#8839ef",
+    "notificationLink.foreground": "#1e66f5",
+    "notificationsErrorIcon.foreground": "#d20f39",
+    "notificationsWarningIcon.foreground": "#fe640b",
+    "notificationsInfoIcon.foreground": "#1e66f5",
+    "panel.background": "#eff1f5",
+    "panel.border": "#acb0be",
+    "panelSection.border": "#acb0be",
+    "panelSection.dropBackground": "#acb0be99",
+    "panelTitle.activeBorder": "#4c4f69",
+    "panelTitle.activeForeground": "#4c4f69",
+    "panelTitle.inactiveForeground": "#6c6f85",
+    "peekView.border": "#8839ef",
+    "peekViewEditor.background": "#e6e9ef",
+    "peekViewEditor.matchHighlightBackground": "#fe640b3f",
+    "peekViewEditor.matchHighlightBorder": "#fe640b",
+    "peekViewEditorGutter.background": "#e6e9ef",
+    "peekViewResult.background": "#e6e9ef",
+    "peekViewResult.fileForeground": "#4c4f69",
+    "peekViewResult.lineForeground": "#4c4f69",
+    "peekViewResult.matchHighlightBackground": "#fe640b3f",
+    "peekViewResult.selectionBackground": "#ccd0da",
+    "peekViewResult.selectionForeground": "#4c4f69",
+    "peekViewTitle.background": "#eff1f5",
+    "peekViewTitleDescription.foreground": "#5c5f77b2",
+    "peekViewTitleLabel.foreground": "#4c4f69",
+    "pickerGroup.border": "#8839ef",
+    "pickerGroup.foreground": "#8839ef",
+    "progressBar.background": "#8839ef",
+    "scrollbar.shadow": "#dce0e8",
+    "scrollbarSlider.activeBackground": "#ccd0da66",
+    "scrollbarSlider.background": "#acb0be7f",
+    "scrollbarSlider.hoverBackground": "#9ca0b0",
+    "settings.focusedRowBackground": "#acb0be33",
+    "settings.headerForeground": "#4c4f69",
+    "settings.modifiedItemIndicator": "#8839ef",
+    "settings.dropdownBackground": "#bcc0cc",
+    "settings.dropdownListBorder": "#00000000",
+    "settings.textInputBackground": "#bcc0cc",
+    "settings.textInputBorder": "#00000000",
+    "settings.numberInputBackground": "#bcc0cc",
+    "settings.numberInputBorder": "#00000000",
+    "sideBar.background": "#e6e9ef",
+    "sideBar.dropBackground": "#acb0be99",
+    "sideBar.foreground": "#4c4f69",
+    "sideBar.border": "#00000000",
+    "sideBarSectionHeader.background": "#e6e9ef",
+    "sideBarSectionHeader.foreground": "#4c4f69",
+    "sideBarTitle.foreground": "#8839ef",
+    "sideBarTitle.background": "#dce0e8",
+    "statusBar.background": "#dce0e8",
+    "statusBar.foreground": "#4c4f69",
+    "statusBar.border": "#00000000",
+    "statusBar.noFolderBackground": "#dce0e8",
+    "statusBar.noFolderForeground": "#4c4f69",
+    "statusBar.debuggingBackground": "#fe640b",
+    "statusBar.debuggingForeground": "#dce0e8",
+    "statusBarItem.remoteBackground": "#1e66f5",
+    "statusBarItem.remoteForeground": "#dce0e8",
+    "statusBarItem.activeBackground": "#acb0be66",
+    "statusBarItem.hoverBackground": "#acb0be33",
+    "statusBarItem.prominentForeground": "#8839ef",
+    "statusBarItem.prominentBackground": "#00000000",
+    "statusBarItem.prominentHoverBackground": "#acb0be33",
+    "statusBarItem.errorForeground": "#d20f39",
+    "statusBarItem.errorBackground": "#00000000",
+    "statusBarItem.warningForeground": "#fe640b",
+    "statusBarItem.warningBackground": "#00000000",
+    "commandCenter.foreground": "#5c5f77",
+    "commandCenter.activeForeground": "#8839ef",
+    "commandCenter.background": "#dce0e8",
+    "commandCenter.activeBackground": "#acb0be33",
+    "commandCenter.border": "#8839ef",
+    "tab.activeBackground": "#eff1f5",
+    "tab.activeBorder": "#8839ef",
+    "tab.activeBorderTop": "#00000000",
+    "tab.activeForeground": "#8839ef",
+    "tab.border": "#e6e9ef",
+    "tab.inactiveBackground": "#e6e9ef",
+    "tab.inactiveForeground": "#9ca0b0",
+    "terminal.ansiBlack": "#9ca0b0",
+    "terminal.ansiBlue": "#1e66f5",
+    "terminal.ansiBrightBlack": "#8c8fa1",
+    "terminal.ansiBrightBlue": "#1e66f5",
+    "terminal.ansiBrightCyan": "#04a5e5",
+    "terminal.ansiBrightGreen": "#40a02b",
+    "terminal.ansiBrightMagenta": "#ea76cb",
+    "terminal.ansiBrightRed": "#d20f39",
+    "terminal.ansiBrightWhite": "#4c4f69",
+    "terminal.ansiBrightYellow": "#df8e1d",
+    "terminal.ansiCyan": "#04a5e5",
+    "terminal.ansiGreen": "#40a02b",
+    "terminal.ansiMagenta": "#ea76cb",
+    "terminal.ansiRed": "#d20f39",
+    "terminal.ansiWhite": "#7c7f93",
+    "terminal.ansiYellow": "#df8e1d",
+    "terminal.border": "#acb0be",
+    "terminal.foreground": "#4c4f69",
+    "terminal.dropBackground": "#acb0be99",
+    "terminal.selectionBackground": "#acb0be",
+    "terminalCursor.background": "#eff1f5",
+    "terminalCursor.foreground": "#dc8a78",
+    "titleBar.activeBackground": "#dce0e8",
+    "titleBar.activeForeground": "#4c4f69",
+    "titleBar.inactiveBackground": "#dce0e8",
+    "titleBar.inactiveForeground": "#4c4f697f",
+    "titleBar.border": "#00000000",
+    "welcomePage.tileBackground": "#e6e9ef",
+    "welcomePage.progress.background": "#dce0e8",
+    "welcomePage.progress.foreground": "#8839ef",
+    "walkThrough.embeddedEditorBackground": "#eff1f54c",
+    "symbolIcon.textForeground": "#4c4f69",
+    "symbolIcon.arrayForeground": "#fe640b",
+    "symbolIcon.booleanForeground": "#8839ef",
+    "symbolIcon.classForeground": "#df8e1d",
+    "symbolIcon.colorForeground": "#ea76cb",
+    "symbolIcon.constantForeground": "#fe640b",
+    "symbolIcon.constructorForeground": "#7287fd",
+    "symbolIcon.enumeratorForeground": "#df8e1d",
+    "symbolIcon.enumeratorMemberForeground": "#df8e1d",
+    "symbolIcon.eventForeground": "#ea76cb",
+    "symbolIcon.fieldForeground": "#4c4f69",
+    "symbolIcon.fileForeground": "#8839ef",
+    "symbolIcon.folderForeground": "#8839ef",
+    "symbolIcon.functionForeground": "#1e66f5",
+    "symbolIcon.interfaceForeground": "#df8e1d",
+    "symbolIcon.keyForeground": "#179299",
+    "symbolIcon.keywordForeground": "#8839ef",
+    "symbolIcon.methodForeground": "#1e66f5",
+    "symbolIcon.moduleForeground": "#4c4f69",
+    "symbolIcon.namespaceForeground": "#df8e1d",
+    "symbolIcon.nullForeground": "#e64553",
+    "symbolIcon.numberForeground": "#fe640b",
+    "symbolIcon.objectForeground": "#df8e1d",
+    "symbolIcon.operatorForeground": "#179299",
+    "symbolIcon.packageForeground": "#dd7878",
+    "symbolIcon.propertyForeground": "#e64553",
+    "symbolIcon.referenceForeground": "#df8e1d",
+    "symbolIcon.snippetForeground": "#dd7878",
+    "symbolIcon.stringForeground": "#40a02b",
+    "symbolIcon.structForeground": "#179299",
+    "symbolIcon.typeParameterForeground": "#e64553",
+    "symbolIcon.unitForeground": "#4c4f69",
+    "symbolIcon.variableForeground": "#4c4f69",
+    "charts.foreground": "#4c4f69",
+    "charts.lines": "#5c5f77",
+    "charts.red": "#d20f39",
+    "charts.blue": "#1e66f5",
+    "charts.yellow": "#df8e1d",
+    "charts.orange": "#fe640b",
+    "charts.green": "#40a02b",
+    "charts.purple": "#8839ef",
+    "errorLens.errorBackground": "#d20f3926",
+    "errorLens.errorMessageBackground": "#d20f3926",
+    "errorLens.errorBackgroundLight": "#d20f3926",
+    "errorLens.errorForeground": "#d20f39",
+    "errorLens.errorForegroundLight": "#d20f39",
+    "errorLens.warningBackground": "#fe640b26",
+    "errorLens.warningMessageBackground": "#fe640b26",
+    "errorLens.warningBackgroundLight": "#fe640b26",
+    "errorLens.warningForeground": "#fe640b",
+    "errorLens.warningForegroundLight": "#fe640b",
+    "errorLens.infoBackground": "#1e66f526",
+    "errorLens.infoMessageBackground": "#1e66f526",
+    "errorLens.infoBackgroundLight": "#1e66f526",
+    "errorLens.infoForeground": "#1e66f5",
+    "errorLens.infoForegroundLight": "#1e66f5",
+    "errorLens.hintBackground": "#40a02b26",
+    "errorLens.hintMessageBackground": "#40a02b26",
+    "errorLens.hintBackgroundLight": "#40a02b26",
+    "errorLens.hintForeground": "#40a02b",
+    "errorLens.hintForegroundLight": "#40a02b",
+    "errorLens.statusBarIconErrorForeground": "#d20f39",
+    "errorLens.statusBarIconWarningForeground": "#fe640b",
+    "errorLens.statusBarErrorForeground": "#d20f39",
+    "errorLens.statusBarWarningForeground": "#fe640b",
+    "errorLens.statusBarInfoForeground": "#1e66f5",
+    "errorLens.statusBarHintForeground": "#40a02b",
+    "editorBracketHighlight.foreground1": "#d20f39",
+    "editorBracketHighlight.foreground2": "#fe640b",
+    "editorBracketHighlight.foreground3": "#df8e1d",
+    "editorBracketHighlight.foreground4": "#40a02b",
+    "editorBracketHighlight.foreground5": "#209fb5",
+    "editorBracketHighlight.foreground6": "#8839ef",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#e64553"
+  }
+}

--- a/shiki/shiki-macchiato-theme.json
+++ b/shiki/shiki-macchiato-theme.json
@@ -1,0 +1,2798 @@
+{
+  "name": "Catppuccin Macchiato",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "semanticTokenColors": {
+    "enumMember": {
+      "foreground": "#91d7e3"
+    },
+    "variable.constant": {
+      "foreground": "#eed49f"
+    },
+    "variable.defaultLibrary": {
+      "foreground": "#f5a97f"
+    }
+  },
+  "tokenColors": [
+    {
+      "name": "All variable",
+      "scope": ["variable.language", "variable.other"],
+      "settings": {
+        "foreground": "#f0c6c6"
+      }
+    },
+    {
+      "name": "All function",
+      "scope": ["entity.name.function", "support.function"],
+      "settings": {
+        "foreground": "#8aadf4",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All parameter",
+      "scope": [
+        "variable.parameter.function",
+        "variable.parameter.function-call"
+      ],
+      "settings": {
+        "foreground": "#f5bde6",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All numeric",
+      "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
+      "settings": {
+        "foreground": "#f5a97f",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All types",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "All conditionals",
+      "scope": [
+        "keyword.control",
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#ed8796",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All punctuation brackets",
+      "scope": [
+        "punctuation.brackets",
+        "punctuation.section",
+        "punctuation.definition"
+      ],
+      "settings": {
+        "foreground": "#8087a2"
+      }
+    },
+    {
+      "name": "All punctuation delimiters",
+      "scope": "punctuation.semi",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "All namespace",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#f4dbd6"
+      }
+    },
+    {
+      "name": "All operators",
+      "scope": [
+        "keyword.operator.comparison",
+        "keyword.operator.assignment",
+        "keyword.operator.arrow.skinny",
+        "keyword.operator.math",
+        "keyword.operator.key-value",
+        "keyword.operator.misc",
+        "keyword.operator.namespace"
+      ],
+      "settings": {
+        "foreground": "#91d7e3",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All built-in constants",
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#b7bdf8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All constants",
+      "scope": "constant.other",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "JSON quoted string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "JSON punctuation string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "JSON punct structure",
+      "scope": [
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json",
+        "source.json meta.structure.array.json > value.json > string.quoted.json",
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation",
+        "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+      ],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "JSON property name",
+      "scope": "support.type.property-name.json.comments",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "JSON constants",
+      "scope": "constant.language.json.comments",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "JSON punctuation",
+      "scope": [
+        "punctuation.separator.dictionary.pair.json.comments",
+        "punctuation.separator.array.json.comments"
+      ],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "JSON brackets",
+      "scope": [
+        "punctuation.definition.dictionary.begin.json.comments",
+        "punctuation.definition.dictionary.end.json.comments",
+        "punctuation.definition.array.begin.json.comments",
+        "punctuation.definition.array.end.json.comments"
+      ],
+      "settings": {
+        "foreground": "#939ab7"
+      }
+    },
+    {
+      "name": "JSON constant language",
+      "scope": [
+        "source.json meta.structure.dictionary.json > constant.language.json",
+        "source.json meta.structure.array.json > constant.language.json"
+      ],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "JSON property name [VSCODE-CUSTOM]",
+      "scope": "support.type.property-name.json",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "unison punctuation",
+      "scope": [
+        "punctuation.definition.delayed.unison",
+        "punctuation.definition.list.begin.unison",
+        "punctuation.definition.list.end.unison",
+        "punctuation.definition.ability.begin.unison",
+        "punctuation.definition.ability.end.unison",
+        "punctuation.operator.assignment.as.unison",
+        "punctuation.separator.pipe.unison",
+        "punctuation.separator.delimiter.unison",
+        "punctuation.definition.hash.unison"
+      ],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "haskell variable generic-type",
+      "scope": "variable.other.generic-type.haskell",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "haskell storage type",
+      "scope": "storage.type.haskell",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "support.variable.magic.python",
+      "scope": "support.variable.magic.python",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "punctuation.separator.parameters.python",
+      "scope": [
+        "punctuation.separator.period.python",
+        "punctuation.separator.element.python",
+        "punctuation.parenthesis.begin.python",
+        "punctuation.parenthesis.end.python"
+      ],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.self.python",
+      "scope": "variable.parameter.function.language.special.self.python",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Rust modifier",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Rust types",
+      "scope": "entity.name.type.rust",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Rust functions std",
+      "scope": "support.function.std.rust",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Rust functions",
+      "scope": "entity.name.function.rust",
+      "settings": {
+        "foreground": "#8aadf4",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust function keyword",
+      "scope": "keyword.other.fn.rust",
+      "settings": {
+        "foreground": "#ee99a0"
+      }
+    },
+    {
+      "name": "Rust conditionals",
+      "scope": "keyword.control.rust",
+      "settings": {
+        "foreground": "#c6a0f6",
+        "fontStyle": "bold italic"
+      }
+    },
+    {
+      "name": "Rust punctuation brackets",
+      "scope": [
+        "punctuation.brackets.curly.rust",
+        "punctuation.brackets.round.rust",
+        "punctuation.brackets.square.rust",
+        "punctuation.brackets.attribute.rust"
+      ],
+      "settings": {
+        "foreground": "#8087a2"
+      }
+    },
+    {
+      "name": "Rust namespace",
+      "scope": "entity.name.namespace.rust",
+      "settings": {
+        "foreground": "#f4dbd6"
+      }
+    },
+    {
+      "name": "Rust punctuation delimiters",
+      "scope": "punctuation.semi.rust",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Rust operators",
+      "scope": [
+        "keyword.operator.comparison.rust",
+        "keyword.operator.assignment.equal.rust",
+        "keyword.operator.arrow.skinny.rust",
+        "keyword.operator.math.rust",
+        "keyword.operator.key-value.rust",
+        "keyword.operator.misc.rust"
+      ],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Rust operator namespaces",
+      "scope": "keyword.operator.namespace.rust",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Rust definition attributes",
+      "scope": [
+        "punctuation.definition.attribute.rust",
+        "keyword.operator.attribute.inner.rust"
+      ],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Rust math logic",
+      "scope": "constant.numeric.decimal.rust",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Rust constants",
+      "scope": "support.constant.core.rust",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Rust entity name",
+      "scope": "entity.name.lifetime.rust",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Rust variable",
+      "scope": ["variable.language.rust", "variable.other.rust"],
+      "settings": {
+        "foreground": "#cad3f5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust misc operators",
+      "scope": "keyword.operator.misc.rust",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Rust sigil operator",
+      "scope": "keyword.operator.sigil.rust",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Lua operators",
+      "scope": "keyword.operator.lua",
+      "settings": {
+        "foreground": "#91d7e3",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua numeric",
+      "scope": "constant.numeric.integer.lua",
+      "settings": {
+        "foreground": "#f5a97f",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua other vars",
+      "scope": "variable.other.lua",
+      "settings": {
+        "foreground": "#b7bdf8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Lua brackets",
+      "scope": [
+        "punctuation.definition.parameters.end.lua",
+        "punctuation.definition.parameters.begin.lua"
+      ],
+      "settings": {
+        "foreground": "#8087a2"
+      }
+    },
+    {
+      "name": "C++ Punct Delimiters",
+      "scope": "punctuation.terminator.statement.cpp",
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ Variables",
+      "scope": "variable.other.local.cpp",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "C++ Operators",
+      "scope": [
+        "punctuation.separator.scope-resolution.cpp",
+        "punctuation.separator.scope-resolution.namespace.alias.cpp",
+        "punctuation.separator.scope-resolution.namespace.using.cpp"
+      ],
+      "settings": {
+        "foreground": "#91d7e3",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ function",
+      "scope": "meta.function.c,meta.function.cpp",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "C++ constructor/destructor",
+      "scope": [
+        "entity.name.function.definition.special.constructor",
+        "entity.name.function.definition.special.member.destructor"
+      ],
+      "settings": {
+        "foreground": "#b7bdf8"
+      }
+    },
+    {
+      "name": "C++ directive",
+      "scope": [
+        "keyword.control.directive",
+        "keyword.other.using.directive",
+        "punctuation.definition.directive"
+      ],
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ ifdef directive",
+      "scope": [
+        "keyword.control.directive.conditional.ifdef.cpp",
+        "keyword.control.directive.else.cpp",
+        "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp",
+        "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
+      ],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "C++ misc",
+      "scope": [
+        "entity.name.other.preprocessor.macro.predefined.probably",
+        "entity.name.scope-resolution.cpp"
+      ],
+      "settings": {
+        "foreground": "#f4dbd6",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ pointer/reference",
+      "scope": [
+        "storage.modifier.pointer.cpp",
+        "storage.modifier.reference.cpp"
+      ],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "C++ loop/conditional",
+      "scope": [
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#c6a0f6",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ return",
+      "scope": "keyword.control.return",
+      "settings": {
+        "foreground": "#f5bde6"
+      }
+    },
+    {
+      "name": "C++ block",
+      "scope": [
+        "punctuation.section.block.begin.bracket.curly.cpp",
+        "punctuation.section.block.end.bracket.curly.cpp",
+        "punctuation.terminator.statement.c",
+        "punctuation.section.block.begin.bracket.curly.c",
+        "punctuation.section.block.end.bracket.curly.c",
+        "punctuation.section.parens.begin.bracket.round.c",
+        "punctuation.section.parens.end.bracket.round.c",
+        "punctuation.section.parameters.begin.bracket.round.c",
+        "punctuation.section.parameters.end.bracket.round.c"
+      ],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "C++ storage type modifier",
+      "scope": "storage.type.built-in.primitive.cpp",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "C++/C#",
+      "scope": [
+        "entity.name.label.cs",
+        "entity.name.scope-resolution.function.call",
+        "entity.name.scope-resolution.function.definition"
+      ],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "support.constant.edge",
+      "scope": "support.constant.edge",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "regexp constant character-class",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "regexp operator.quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "punctuation.definition",
+      "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": "comment markup.link",
+      "settings": {
+        "foreground": "#6e738d"
+      }
+    },
+    {
+      "name": "markup diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "diff",
+      "scope": [
+        "meta.diff.header.from-file",
+        "meta.diff.header.to-file",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.to-file.diff"
+      ],
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "inserted.diff",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "deleted.diff",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Quote multi",
+      "scope": [
+        "string.quoted.docstring.multi",
+        "string.quoted.multi",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.end.python",
+        "markup.fenced_code.block"
+      ],
+      "settings": {
+        "foreground": "#a6da95",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "js/ts punctuation separator key-value",
+      "scope": "punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "js/ts import keyword",
+      "scope": "keyword.operator.expression.import",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "math js/ts",
+      "scope": "support.constant.math",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "math property js/ts",
+      "scope": "support.constant.property.math",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "js/ts variable.other.constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "java type",
+      "scope": [
+        "storage.type.annotation.java",
+        "storage.type.object.array.java"
+      ],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "java source",
+      "scope": "source.java",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": [
+        "punctuation.section.block.begin.java",
+        "punctuation.section.block.end.java",
+        "punctuation.definition.method-parameters.begin.java",
+        "punctuation.definition.method-parameters.end.java",
+        "meta.method.identifier.java",
+        "punctuation.section.method.begin.java",
+        "punctuation.section.method.end.java",
+        "punctuation.terminator.java",
+        "punctuation.section.class.begin.java",
+        "punctuation.section.class.end.java",
+        "punctuation.section.inner-class.begin.java",
+        "punctuation.section.inner-class.end.java",
+        "meta.method-call.java",
+        "punctuation.section.class.begin.bracket.curly.java",
+        "punctuation.section.class.end.bracket.curly.java",
+        "punctuation.section.method.begin.bracket.curly.java",
+        "punctuation.section.method.end.bracket.curly.java",
+        "punctuation.separator.period.java",
+        "punctuation.bracket.angle.java",
+        "punctuation.definition.annotation.java",
+        "meta.method.body.java"
+      ],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "meta.method.java",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "java variable.name",
+      "scope": "meta.definition.variable.name.java",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "operator logical",
+      "scope": ["keyword.operator.logical", "keyword.operator.ternary"],
+      "settings": {
+        "foreground": "#91d7e3",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "operator bitwise",
+      "scope": "keyword.operator.bitwise",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "support.constant.property-value.scss",
+      "scope": [
+        "support.constant.property-value.scss",
+        "support.constant.property-value.css"
+      ],
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": [
+        "keyword.operator.css",
+        "keyword.operator.scss",
+        "keyword.operator.less"
+      ],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "css color standard name",
+      "scope": [
+        "support.constant.color.w3c-standard-color-name.css",
+        "support.constant.color.w3c-standard-color-name.scss"
+      ],
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "css comma",
+      "scope": "punctuation.separator.list.comma.css",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "css attribute-name.id",
+      "scope": "support.constant.color.w3c-standard-color-name.css",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "css property-name",
+      "scope": "support.type.vendored.property-name.css",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "js/ts module",
+      "scope": [
+        "support.module.node",
+        "support.type.object.module",
+        "support.module.node"
+      ],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "entity.name.type.module",
+      "scope": "entity.name.type.module",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "js variable readwrite",
+      "scope": [
+        "variable.other.readwrite",
+        "meta.object-literal.key",
+        "support.variable.property",
+        "support.variable.object.process",
+        "support.variable.object.node"
+      ],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "js/ts json",
+      "scope": "support.constant.json",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "js/ts Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.ternary",
+        "keyword.operator.optional",
+        "keyword.operator.expression.keyof"
+      ],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "js/ts console",
+      "scope": "support.type.object.console",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "js/ts support.variable.property.process",
+      "scope": "support.variable.property.process",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "js console function",
+      "scope": "entity.name.function,support.function.console",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "operator",
+      "scope": "keyword.operator.delete",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "js dom",
+      "scope": "support.type.object.dom",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "js dom variable",
+      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": [
+        "keyword.operator.arithmetic",
+        "keyword.operator.comparison",
+        "keyword.operator.decrement",
+        "keyword.operator.increment",
+        "keyword.operator.relational"
+      ],
+      "settings": {
+        "foreground": "#91d7e3",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C operators",
+      "scope": [
+        "keyword.operator.c",
+        "keyword.operator.increment.c",
+        "keyword.operator.decrement.c",
+        "keyword.operator.bitwise.shift.c",
+        "keyword.operator.cpp",
+        "keyword.operator.increment.cpp",
+        "keyword.operator.decrement.cpp",
+        "keyword.operator.bitwise.shift.cpp"
+      ],
+      "settings": {
+        "foreground": "#91d7e3",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Other punctuation .c",
+      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "C type posix-reserved",
+      "scope": [
+        "support.type.posix-reserved.c",
+        "support.type.posix-reserved.cpp"
+      ],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "keyword.operator.sizeof.c",
+      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "python type",
+      "scope": "support.type.python",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "python block",
+      "scope": [
+        "punctuation.definition.arguments.begin.python",
+        "punctuation.definition.arguments.end.python",
+        "punctuation.separator.arguments.python",
+        "punctuation.definition.list.begin.python",
+        "punctuation.definition.list.end.python"
+      ],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "python function-call.generic",
+      "scope": "meta.function-call.generic.python",
+      "settings": {
+        "foreground": "#8aadf4",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#91d7e3",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Java Variables",
+      "scope": "token.variable.parameter.java",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Java Imports",
+      "scope": "import.storage.java",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package.keyword",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Functions",
+      "scope": [
+        "entity.name.function",
+        "meta.require",
+        "support.function.any-method",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#8aadf4",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "entity.name.type.namespace",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "support.class, entity.name.type.class",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": "entity.name.class.identifier.namespace.type",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "variable.other.class.js",
+        "variable.other.class.ts"
+      ],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Class name php",
+      "scope": "variable.other.class.php",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Type Name",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Control Elements",
+      "scope": "control.elements, keyword.operator.less",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Methods",
+      "scope": "keyword.other.special-method",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Storage JS TS",
+      "scope": "token.storage",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete, In, Of, Instanceof, New, Typeof, Void",
+      "scope": [
+        "keyword.operator.expression.delete",
+        "keyword.operator.expression.in",
+        "keyword.operator.expression.of",
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.expression.typeof",
+        "keyword.operator.expression.void"
+      ],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Java Storage",
+      "scope": "token.storage.type.java",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Support",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.property-value",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.font-name",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Meta tag",
+      "scope": "meta.tag",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": "string",
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "Inherited Class",
+      "scope": "entity.other.inherited-class",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Constant other symbol",
+      "scope": "constant.other.symbol",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Integers",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "constant",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "punctuation.definition.constant",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Tags",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#c6a0f6"
+      }
+    },
+    {
+      "name": "Attributes",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Attribute IDs",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Attribute class",
+      "scope": "entity.other.attribute-name.class.css",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "SCSS variables",
+      "scope": "variable.scss",
+      "settings": {
+        "foreground": "#c6a0f6"
+      }
+    },
+    {
+      "name": "Selector",
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Units",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "markup.bold,todo.bold",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "punctuation.definition.bold",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "markup Italic",
+      "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "emphasis md",
+      "scope": "emphasis md",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "punctuation.definition.list.begin.markdown",
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "punctuation.definition.list.markdown",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "beginning.punctuation.definition.list.markdown",
+      "scope": ["beginning.punctuation.definition.list.markdown"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Regular Expressions",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Escape Characters",
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded, variable.interpolation",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "illegal, deprecated",
+      "scope": "invalid.illegal, invalid.deprecated",
+      "settings": {
+        "foreground": "#6e738d",
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal.bad-ampersand.html",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Broken",
+      "scope": "invalid.broken",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Unimplemented",
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "foreground": "#a5adcb"
+      }
+    },
+    {
+      "name": "laravel blade tag",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "laravel blade @",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "use statement for other classes",
+      "scope": [
+        "support.other.namespace.use.php",
+        "support.other.namespace.use-as.php",
+        "support.other.namespace.php",
+        "entity.other.alias.php",
+        "meta.interface.php"
+      ],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "error suppression",
+      "scope": "keyword.operator.error-control.php",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "php instanceof",
+      "scope": "keyword.operator.type.php",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "style double quoted array index normal begin",
+      "scope": "punctuation.section.array.begin.php",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "style double quoted array index normal end",
+      "scope": "punctuation.section.array.end.php",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "php illegal.non-null-typehinted",
+      "scope": "invalid.illegal.non-null-typehinted.php",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "php types",
+      "scope": [
+        "storage.type.php",
+        "meta.other.type.phpdoc.php",
+        "keyword.other.type.php",
+        "keyword.other.array.phpdoc.php"
+      ],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "php call-function",
+      "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "php function-resets",
+      "scope": [
+        "punctuation.definition.parameters.begin.bracket.round.php",
+        "punctuation.definition.parameters.end.bracket.round.php",
+        "punctuation.separator.delimiter.php",
+        "punctuation.section.scope.begin.php",
+        "punctuation.section.scope.end.php",
+        "punctuation.terminator.expression.php",
+        "punctuation.definition.arguments.begin.bracket.round.php",
+        "punctuation.definition.arguments.end.bracket.round.php",
+        "punctuation.definition.storage-type.begin.bracket.round.php",
+        "punctuation.definition.storage-type.end.bracket.round.php",
+        "punctuation.definition.array.begin.bracket.round.php",
+        "punctuation.definition.array.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.round.php",
+        "punctuation.definition.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.curly.php",
+        "punctuation.definition.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.start.bracket.curly.php",
+        "punctuation.definition.section.switch-block.begin.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php"
+      ],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": [
+        "support.constant.ext.php",
+        "support.constant.std.php",
+        "support.constant.core.php",
+        "support.constant.parser-token.php"
+      ],
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "php goto",
+      "scope": "entity.name.goto-label.php,support.other.php",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "php logical/bitwise operator",
+      "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "php regexp operator",
+      "scope": "keyword.operator.regexp.php",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "php comparison",
+      "scope": "keyword.operator.comparison.php",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "php heredoc/nowdoc",
+      "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "python function decorator @",
+      "scope": "meta.function.decorator.python",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": [
+        "support.token.decorator.python",
+        "meta.function.decorator.identifier.python"
+      ],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "parameter function js/ts",
+      "scope": "function.parameter",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "brace function",
+      "scope": "function.brace",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "parameter function ruby cs",
+      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "constant.language.symbol.ruby",
+      "scope": "constant.language.symbol.ruby",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "rgb-value",
+      "scope": "rgb-value",
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "rgb value",
+      "scope": "inline-color-decoration rgb-value",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "rgb value less",
+      "scope": "less rgb-value",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "sass selector",
+      "scope": "selector.sass",
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "ts primitive/builtin types",
+      "scope": [
+        "support.type.primitive.ts",
+        "support.type.builtin.ts",
+        "support.type.primitive.tsx",
+        "support.type.builtin.tsx"
+      ],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "block scope",
+      "scope": "block.scope.end,block.scope.begin",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "cs storage type",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "cs local variable",
+      "scope": "entity.name.variable.local.cs",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": ["meta.template.expression"],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Import module JS",
+      "scope": ["keyword.operator.module"],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "js Flowtype",
+      "scope": ["support.type.type.flowtype"],
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "js Flow",
+      "scope": ["support.type.primitive"],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "js class prop",
+      "scope": ["meta.property.object"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "js func parameter",
+      "scope": ["variable.parameter.function.js"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "js template literals begin",
+      "scope": ["keyword.other.template.begin"],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "js template literals end",
+      "scope": ["keyword.other.template.end"],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "js template literals variable braces begin",
+      "scope": ["keyword.other.substitution.begin"],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "js template literals variable braces end",
+      "scope": ["keyword.other.substitution.end"],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.arithmetic.go",
+        "keyword.operator.address.go"
+      ],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "Go package name",
+      "scope": ["entity.name.package.go"],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Go import statement",
+      "scope": "keyword.import.go",
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "elm prelude",
+      "scope": ["support.type.prelude.elm"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "elm constant",
+      "scope": ["support.constant.elm"],
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": ["punctuation.quasi.element"],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": ["constant.character.entity"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+      "scope": [
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.pseudo-class"
+      ],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": ["entity.global.clojure"],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": ["meta.symbol.clojure"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": ["constant.keyword.clojure"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": ["source.ini"],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "Shell definition variables",
+      "scope": ["punctuation.definition.variable.shell"],
+      "settings": {
+        "foreground": "#8087a2"
+      }
+    },
+    {
+      "name": "Shell logical operators",
+      "scope": ["keyword.operator.logical.shell"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Shell clauses",
+      "scope": ["meta.scope.case-clause-body.shell"],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Shell funcs",
+      "scope": ["meta.scope.group.shell"],
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Shell interpolated cmds",
+      "scope": ["string.interpolated.dollar.shell"],
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "Shell interpolated strings",
+      "scope": ["string.quoted.single.shell"],
+      "settings": {
+        "foreground": "#b7bdf8"
+      }
+    },
+    {
+      "name": "Shell pipe symbol",
+      "scope": ["keyword.operator.pipe.shell"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "Shell group definition",
+      "scope": ["punctuation.definition.group.shell"],
+      "settings": {
+        "foreground": "#8087a2"
+      }
+    },
+    {
+      "name": "Shell conditionals",
+      "scope": ["keyword.control.shell"],
+      "settings": {
+        "foreground": "#c6a0f6"
+      }
+    },
+    {
+      "name": "Shell operators and punct delimiters",
+      "scope": ["keyword.operator.list.shell"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Shell parenthesis",
+      "scope": ["punctuation.definition.logical-expression.shell"],
+      "settings": {
+        "foreground": "#8087a2"
+      }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": ["meta.scope.prerequisites.makefile"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": ["source.makefile"],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": ["storage.modifier.import.groovy"],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": ["meta.method.groovy"],
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": ["meta.definition.variable.name.groovy"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": ["meta.definition.class.inherited.classes.groovy"],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": ["support.variable.semantic.hlsl"],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "SQL Variables",
+      "scope": ["text.variable", "text.bracketed"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "types",
+      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "settings": {
+        "foreground": "#f5a97f"
+      }
+    },
+    {
+      "name": "heading 1, keyword",
+      "scope": ["entity.name.function.xi"],
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "heading 2, callable",
+      "scope": ["entity.name.class.xi"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "heading 3, property",
+      "scope": ["constant.character.character-class.regexp.xi"],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "heading 4, type, class, interface",
+      "scope": ["constant.regexp.xi"],
+      "settings": {
+        "foreground": "#ed8796"
+      }
+    },
+    {
+      "name": "heading 5, enums, preprocessor, constant, decorator",
+      "scope": ["keyword.control.xi"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "heading 6, number",
+      "scope": ["invalid.xi"],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "string",
+      "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+      "settings": {
+        "foreground": "#a6da95"
+      }
+    },
+    {
+      "name": "comments",
+      "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+      "settings": {
+        "foreground": "#6e738d"
+      }
+    },
+    {
+      "name": "link",
+      "scope": ["constant.character.xi"],
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "accent",
+      "scope": ["accent.xi"],
+      "settings": {
+        "foreground": "#8aadf4"
+      }
+    },
+    {
+      "name": "wikiword",
+      "scope": ["wikiword.xi"],
+      "settings": {
+        "foreground": "#eed49f"
+      }
+    },
+    {
+      "name": "language operators like '+', '-' etc",
+      "scope": ["constant.other.color.rgb-value.xi"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "elements to dim",
+      "scope": ["punctuation.definition.tag.xi"],
+      "settings": {
+        "foreground": "#6e738d"
+      }
+    },
+    {
+      "name": "Markdown underscore-style headers",
+      "scope": [
+        "entity.name.label.cs",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.setext.2.markdown"
+      ],
+      "settings": {
+        "foreground": "#8bd5ca"
+      }
+    },
+    {
+      "name": "meta.brace.square",
+      "scope": [" meta.brace.square"],
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": "comment, punctuation.definition.comment",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#6e738d"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": {
+        "foreground": "#6e738d"
+      }
+    },
+    {
+      "name": "punctuation.definition.block.sequence.item.yaml",
+      "scope": "punctuation.definition.block.sequence.item.yaml",
+      "settings": {
+        "foreground": "#cad3f5"
+      }
+    },
+    {
+      "scope": ["constant.language.symbol.elixir"],
+      "settings": {
+        "foreground": "#91d7e3"
+      }
+    },
+    {
+      "name": "js/ts italic",
+      "scope": [
+        "entity.other.attribute-name.js",
+        "entity.other.attribute-name.ts",
+        "entity.other.attribute-name.jsx",
+        "entity.other.attribute-name.tsx",
+        "variable.parameter",
+        "variable.language.super"
+      ],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "comment",
+      "scope": "comment.line.double-slash,comment.block.documentation",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword import",
+      "scope": "keyword.control.import.python",
+      "settings": {
+        "foreground": "#8bd5ca",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword flow",
+      "scope": "keyword.control.flow.python",
+      "settings": {
+        "foreground": "#c6a0f6",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "python storage type",
+      "scope": "storage.type.function.python",
+      "settings": {
+        "foreground": "#ee99a0",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "markup.italic.markdown",
+      "scope": "markup.italic.markdown",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "invalid.deprecated.line-too-long.git-commit",
+      "scope": "invalid.deprecated.line-too-long.git-commit",
+      "settings": {
+        "foreground": "#eed49f",
+        "fontStyle": "underline"
+      }
+    }
+  ],
+  "colors": {
+    "focusBorder": "#00000000",
+    "foreground": "#cad3f5",
+    "disabledForeground": "#a5adcb",
+    "widget.shadow": "#1e20307f",
+    "selection.background": "#5b6078",
+    "descriptionForeground": "#cad3f5",
+    "errorForeground": "#ed8796",
+    "icon.foreground": "#c6a0f6",
+    "sash.hoverBorder": "#c6a0f6",
+    "window.activeBorder": "#00000000",
+    "window.inactiveBorder": "#00000000",
+    "textBlockQuote.background": "#1e2030",
+    "textBlockQuote.border": "#181926",
+    "textCodeBlock.background": "#24273a",
+    "textLink.activeForeground": "#91d7e3",
+    "textLink.foreground": "#8aadf4",
+    "textPreformat.foreground": "#cad3f5",
+    "textSeparator.foreground": "#c6a0f6",
+    "activityBar.background": "#181926",
+    "activityBar.foreground": "#c6a0f6",
+    "activityBar.dropBar": "#5b607899",
+    "activityBar.inactiveForeground": "#6e738d",
+    "activityBar.border": "#00000000",
+    "activityBarBadge.background": "#c6a0f6",
+    "activityBarBadge.foreground": "#181926",
+    "activityBar.activeBorder": "#00000000",
+    "activityBar.activeBackground": "#00000000",
+    "activityBar.activeFocusBorder": "#00000000",
+    "badge.background": "#494d64",
+    "badge.foreground": "#cad3f5",
+    "breadcrumb.activeSelectionForeground": "#c6a0f6",
+    "breadcrumb.background": "#1e2030",
+    "breadcrumb.focusForeground": "#c6a0f6",
+    "breadcrumb.foreground": "#cad3f5cc",
+    "breadcrumbPicker.background": "#1e2030",
+    "button.background": "#c6a0f6",
+    "button.foreground": "#181926",
+    "button.border": "#00000000",
+    "button.separator": "#00000000",
+    "button.hoverBackground": "#dab4ff",
+    "button.secondaryForeground": "#cad3f5",
+    "button.secondaryBackground": "#5b6078",
+    "button.secondaryHoverBackground": "#6f748c",
+    "checkbox.background": "#494d64",
+    "checkbox.border": "#00000000",
+    "checkbox.foreground": "#c6a0f6",
+    "dropdown.background": "#1e2030",
+    "dropdown.listBackground": "#5b6078",
+    "dropdown.border": "#c6a0f6",
+    "dropdown.foreground": "#cad3f5",
+    "debugToolBar.background": "#181926",
+    "debugToolBar.border": "#00000000",
+    "debugExceptionWidget.background": "#181926",
+    "debugExceptionWidget.border": "#c6a0f6",
+    "debugTokenExpression.number": "#f5a97f",
+    "debugTokenExpression.boolean": "#c6a0f6",
+    "debugTokenExpression.string": "#a6da95",
+    "debugTokenExpression.error": "#ed8796",
+    "debugIcon.breakpointForeground": "#ed8796",
+    "debugIcon.breakpointDisabledForeground": "#ed879699",
+    "debugIcon.breakpointUnverifiedForeground": "#24273a",
+    "debugIcon.breakpointCurrentStackframeForeground": "#5b6078",
+    "debugIcon.breakpointStackframeForeground": "#5b6078",
+    "debugIcon.startForeground": "#a6da95",
+    "debugIcon.pauseForeground": "#8aadf4",
+    "debugIcon.stopForeground": "#ed8796",
+    "debugIcon.disconnectForeground": "#5b6078",
+    "debugIcon.restartForeground": "#8bd5ca",
+    "debugIcon.stepOverForeground": "#c6a0f6",
+    "debugIcon.stepIntoForeground": "#cad3f5",
+    "debugIcon.stepOutForeground": "#cad3f5",
+    "debugIcon.continueForeground": "#a6da95",
+    "debugIcon.stepBackForeground": "#5b6078",
+    "debugConsole.infoForeground": "#8aadf4",
+    "debugConsole.warningForeground": "#f5a97f",
+    "debugConsole.errorForeground": "#ed8796",
+    "debugConsole.sourceForeground": "#f4dbd6",
+    "debugConsoleInputIcon.foreground": "#cad3f5",
+    "diffEditor.border": "#5b6078",
+    "diffEditor.insertedTextBackground": "#a6da9519",
+    "diffEditor.removedTextBackground": "#ed879619",
+    "diffEditor.insertedLineBackground": "#a6da9526",
+    "diffEditor.removedLineBackground": "#ed879626",
+    "diffEditor.diagonalFill": "#5b607899",
+    "diffEditorOverview.insertedForeground": "#a6da95cc",
+    "diffEditorOverview.removedForeground": "#ed8796cc",
+    "editor.background": "#24273a",
+    "editor.findMatchBackground": "#5b6078",
+    "editor.findMatchBorder": "#c6a0f666",
+    "editor.findMatchHighlightBackground": "#f5a97f59",
+    "editor.findMatchHighlightBorder": "#00000000",
+    "editor.findRangeHighlightBackground": "#5b60784c",
+    "editor.findRangeHighlightBorder": "#00000000",
+    "editor.foldBackground": "#91d7e33f",
+    "editor.foreground": "#cad3f5",
+    "editor.hoverHighlightBackground": "#91d7e33f",
+    "editor.inactiveSelectionBackground": "#00000000",
+    "editor.lineHighlightBackground": "#cad3f511",
+    "editor.lineHighlightBorder": "#24273a",
+    "editor.rangeHighlightBackground": "#91d7e33f",
+    "editor.rangeHighlightBorder": "#00000000",
+    "editor.selectionBackground": "#5b6078",
+    "editor.selectionHighlightBackground": "#939ab766",
+    "editor.selectionHighlightBorder": "#91d7e333",
+    "editor.wordHighlightBackground": "#5b6078b2",
+    "editor.wordHighlightStrongBackground": "#5b60787f",
+    "editorBracketMatch.background": "#939ab719",
+    "editorBracketMatch.border": "#939ab7",
+    "editorCodeLens.foreground": "#8087a2",
+    "editorCursor.background": "#24273a",
+    "editorCursor.foreground": "#f4dbd6",
+    "editorError.background": "#00000000",
+    "editorError.border": "#00000000",
+    "editorError.foreground": "#ed8796",
+    "editorGroup.border": "#5b6078",
+    "editorGroup.dropBackground": "#5b607899",
+    "editorGroup.emptyBackground": "#24273a",
+    "editorGroupHeader.tabsBackground": "#181926",
+    "editorGutter.addedBackground": "#a6da95",
+    "editorGutter.background": "#24273a",
+    "editorGutter.commentRangeForeground": "#939ab7",
+    "editorGutter.deletedBackground": "#ed8796",
+    "editorGutter.foldingControlForeground": "#939ab7",
+    "editorGutter.modifiedBackground": "#91d7e3",
+    "editorHoverWidget.background": "#1e2030",
+    "editorHoverWidget.border": "#5b6078",
+    "editorHoverWidget.foreground": "#cad3f5",
+    "editorIndentGuide.activeBackground": "#5b6078",
+    "editorIndentGuide.background": "#494d64",
+    "editorInfo.background": "#00000000",
+    "editorInfo.border": "#00000000",
+    "editorInfo.foreground": "#8aadf4",
+    "editorInlayHint.foreground": "#5b6078",
+    "editorInlayHint.background": "#1e2030bf",
+    "editorInlayHint.typeForeground": "#b8c0e0",
+    "editorInlayHint.typeBackground": "#1e2030bf",
+    "editorInlayHint.parameterForeground": "#a5adcb",
+    "editorInlayHint.parameterBackground": "#1e2030bf",
+    "editorLineNumber.activeForeground": "#c6a0f6",
+    "editorLineNumber.foreground": "#8087a2",
+    "editorLink.activeForeground": "#c6a0f6",
+    "editorMarkerNavigation.background": "#1e2030",
+    "editorMarkerNavigationError.background": "#ed8796",
+    "editorMarkerNavigationInfo.background": "#8aadf4",
+    "editorMarkerNavigationWarning.background": "#eed49f",
+    "editorOverviewRuler.background": "#1e2030",
+    "editorOverviewRuler.border": "#cad3f511",
+    "editorRuler.foreground": "#5b6078",
+    "editor.stackFrameHighlightBackground": "#eed49f26",
+    "editor.focusedStackFrameHighlightBackground": "#a6da9526",
+    "editorStickyScrollHover.background": "#363a4f",
+    "editorSuggestWidget.background": "#1e2030",
+    "editorSuggestWidget.border": "#5b6078",
+    "editorSuggestWidget.foreground": "#cad3f5",
+    "editorSuggestWidget.highlightForeground": "#c6a0f6",
+    "editorSuggestWidget.selectedBackground": "#363a4f",
+    "editorWarning.background": "#00000000",
+    "editorWarning.border": "#00000000",
+    "editorWarning.foreground": "#f5a97f",
+    "editorWhitespace.foreground": "#939ab766",
+    "editorWidget.background": "#1e2030",
+    "editorWidget.foreground": "#cad3f5",
+    "editorWidget.resizeBorder": "#5b6078",
+    "editorLightBulb.foreground": "#eed49f",
+    "extensionButton.prominentForeground": "#181926",
+    "extensionButton.prominentBackground": "#c6a0f6",
+    "extensionButton.prominentHoverBackground": "#dab4ff",
+    "extensionBadge.remoteBackground": "#8aadf4",
+    "extensionBadge.remoteForeground": "#181926",
+    "extensionIcon.starForeground": "#eed49f",
+    "extensionIcon.verifiedForeground": "#a6da95",
+    "extensionIcon.preReleaseForeground": "#f4dbd6",
+    "extensionIcon.sponsorForeground": "#f5bde6",
+    "gitDecoration.addedResourceForeground": "#a6da95",
+    "gitDecoration.conflictingResourceForeground": "#c6a0f6",
+    "gitDecoration.deletedResourceForeground": "#ed8796",
+    "gitDecoration.ignoredResourceForeground": "#6e738d",
+    "gitDecoration.modifiedResourceForeground": "#eed49f",
+    "gitDecoration.stageDeletedResourceForeground": "#ed8796",
+    "gitDecoration.stageModifiedResourceForeground": "#eed49f",
+    "gitDecoration.submoduleResourceForeground": "#8aadf4",
+    "gitDecoration.untrackedResourceForeground": "#a6da95",
+    "input.background": "#363a4f",
+    "input.border": "#00000000",
+    "input.foreground": "#cad3f5",
+    "input.placeholderForeground": "#cad3f572",
+    "inputOption.activeBackground": "#8aadf426",
+    "inputOption.activeBorder": "#18192633",
+    "inputOption.activeForeground": "#cad3f5",
+    "inputValidation.errorBackground": "#ed8796",
+    "inputValidation.errorBorder": "#18192633",
+    "inputValidation.errorForeground": "#181926",
+    "inputValidation.infoBackground": "#8aadf4",
+    "inputValidation.infoBorder": "#18192633",
+    "inputValidation.infoForeground": "#181926",
+    "inputValidation.warningBackground": "#f5a97f",
+    "inputValidation.warningBorder": "#18192633",
+    "inputValidation.warningForeground": "#181926",
+    "list.activeSelectionBackground": "#494d64",
+    "list.activeSelectionForeground": "#cad3f5",
+    "list.dropBackground": "#5b607899",
+    "list.focusBackground": "#363a4f",
+    "list.focusForeground": "#cad3f5",
+    "list.focusOutline": "#00000000",
+    "list.highlightForeground": "#c6a0f6",
+    "list.hoverBackground": "#24273a",
+    "list.hoverForeground": "#cad3f5",
+    "list.inactiveSelectionBackground": "#494d64",
+    "list.inactiveSelectionForeground": "#cad3f5",
+    "list.warningForeground": "#eed49f",
+    "listFilterWidget.background": "#494d64",
+    "listFilterWidget.noMatchesOutline": "#ed8796",
+    "listFilterWidget.outline": "#00000000",
+    "tree.indentGuidesStroke": "#6e738d",
+    "menu.background": "#24273a",
+    "menu.border": "#24273a7f",
+    "menu.foreground": "#cad3f5",
+    "menu.selectionBackground": "#5b6078",
+    "menu.selectionBorder": "#00000000",
+    "menu.selectionForeground": "#cad3f5",
+    "menu.separatorBackground": "#5b6078",
+    "menubar.selectionBackground": "#494d64",
+    "menubar.selectionForeground": "#cad3f5",
+    "merge.commonContentBackground": "#494d64",
+    "merge.commonHeaderBackground": "#5b6078",
+    "merge.currentContentBackground": "#a6da9533",
+    "merge.currentHeaderBackground": "#a6da9566",
+    "merge.incomingContentBackground": "#8aadf433",
+    "merge.incomingHeaderBackground": "#8aadf466",
+    "minimap.background": "#1e20307f",
+    "minimap.errorHighlight": "#ed8796",
+    "minimap.findMatchHighlight": "#5b6078",
+    "minimap.selectionHighlight": "#5b6078",
+    "minimap.warningHighlight": "#eed49f",
+    "minimapGutter.addedBackground": "#a6da95",
+    "minimapGutter.deletedBackground": "#ed8796",
+    "minimapGutter.modifiedBackground": "#91d7e3",
+    "notificationCenter.border": "#c6a0f6",
+    "notificationCenterHeader.foreground": "#cad3f5",
+    "notificationCenterHeader.background": "#1e2030",
+    "notificationToast.border": "#c6a0f6",
+    "notifications.foreground": "#cad3f5",
+    "notifications.background": "#1e2030",
+    "notifications.border": "#c6a0f6",
+    "notificationLink.foreground": "#8aadf4",
+    "notificationsErrorIcon.foreground": "#ed8796",
+    "notificationsWarningIcon.foreground": "#f5a97f",
+    "notificationsInfoIcon.foreground": "#8aadf4",
+    "panel.background": "#24273a",
+    "panel.border": "#5b6078",
+    "panelSection.border": "#5b6078",
+    "panelSection.dropBackground": "#5b607899",
+    "panelTitle.activeBorder": "#cad3f5",
+    "panelTitle.activeForeground": "#cad3f5",
+    "panelTitle.inactiveForeground": "#a5adcb",
+    "peekView.border": "#c6a0f6",
+    "peekViewEditor.background": "#1e2030",
+    "peekViewEditor.matchHighlightBackground": "#f5a97f3f",
+    "peekViewEditor.matchHighlightBorder": "#f5a97f",
+    "peekViewEditorGutter.background": "#1e2030",
+    "peekViewResult.background": "#1e2030",
+    "peekViewResult.fileForeground": "#cad3f5",
+    "peekViewResult.lineForeground": "#cad3f5",
+    "peekViewResult.matchHighlightBackground": "#f5a97f3f",
+    "peekViewResult.selectionBackground": "#363a4f",
+    "peekViewResult.selectionForeground": "#cad3f5",
+    "peekViewTitle.background": "#24273a",
+    "peekViewTitleDescription.foreground": "#b8c0e0b2",
+    "peekViewTitleLabel.foreground": "#cad3f5",
+    "pickerGroup.border": "#c6a0f6",
+    "pickerGroup.foreground": "#c6a0f6",
+    "progressBar.background": "#c6a0f6",
+    "scrollbar.shadow": "#181926",
+    "scrollbarSlider.activeBackground": "#363a4f66",
+    "scrollbarSlider.background": "#5b60787f",
+    "scrollbarSlider.hoverBackground": "#6e738d",
+    "settings.focusedRowBackground": "#5b607833",
+    "settings.headerForeground": "#cad3f5",
+    "settings.modifiedItemIndicator": "#c6a0f6",
+    "settings.dropdownBackground": "#494d64",
+    "settings.dropdownListBorder": "#00000000",
+    "settings.textInputBackground": "#494d64",
+    "settings.textInputBorder": "#00000000",
+    "settings.numberInputBackground": "#494d64",
+    "settings.numberInputBorder": "#00000000",
+    "sideBar.background": "#1e2030",
+    "sideBar.dropBackground": "#5b607899",
+    "sideBar.foreground": "#cad3f5",
+    "sideBar.border": "#00000000",
+    "sideBarSectionHeader.background": "#1e2030",
+    "sideBarSectionHeader.foreground": "#cad3f5",
+    "sideBarTitle.foreground": "#c6a0f6",
+    "sideBarTitle.background": "#181926",
+    "statusBar.background": "#181926",
+    "statusBar.foreground": "#cad3f5",
+    "statusBar.border": "#00000000",
+    "statusBar.noFolderBackground": "#181926",
+    "statusBar.noFolderForeground": "#cad3f5",
+    "statusBar.debuggingBackground": "#f5a97f",
+    "statusBar.debuggingForeground": "#181926",
+    "statusBarItem.remoteBackground": "#8aadf4",
+    "statusBarItem.remoteForeground": "#181926",
+    "statusBarItem.activeBackground": "#5b607866",
+    "statusBarItem.hoverBackground": "#5b607833",
+    "statusBarItem.prominentForeground": "#c6a0f6",
+    "statusBarItem.prominentBackground": "#00000000",
+    "statusBarItem.prominentHoverBackground": "#5b607833",
+    "statusBarItem.errorForeground": "#ed8796",
+    "statusBarItem.errorBackground": "#00000000",
+    "statusBarItem.warningForeground": "#f5a97f",
+    "statusBarItem.warningBackground": "#00000000",
+    "commandCenter.foreground": "#b8c0e0",
+    "commandCenter.activeForeground": "#c6a0f6",
+    "commandCenter.background": "#181926",
+    "commandCenter.activeBackground": "#5b607833",
+    "commandCenter.border": "#c6a0f6",
+    "tab.activeBackground": "#24273a",
+    "tab.activeBorder": "#c6a0f6",
+    "tab.activeBorderTop": "#00000000",
+    "tab.activeForeground": "#c6a0f6",
+    "tab.border": "#1e2030",
+    "tab.inactiveBackground": "#1e2030",
+    "tab.inactiveForeground": "#6e738d",
+    "terminal.ansiBlack": "#6e738d",
+    "terminal.ansiBlue": "#8aadf4",
+    "terminal.ansiBrightBlack": "#8087a2",
+    "terminal.ansiBrightBlue": "#8aadf4",
+    "terminal.ansiBrightCyan": "#91d7e3",
+    "terminal.ansiBrightGreen": "#a6da95",
+    "terminal.ansiBrightMagenta": "#f5bde6",
+    "terminal.ansiBrightRed": "#ed8796",
+    "terminal.ansiBrightWhite": "#cad3f5",
+    "terminal.ansiBrightYellow": "#eed49f",
+    "terminal.ansiCyan": "#91d7e3",
+    "terminal.ansiGreen": "#a6da95",
+    "terminal.ansiMagenta": "#f5bde6",
+    "terminal.ansiRed": "#ed8796",
+    "terminal.ansiWhite": "#939ab7",
+    "terminal.ansiYellow": "#eed49f",
+    "terminal.border": "#5b6078",
+    "terminal.foreground": "#cad3f5",
+    "terminal.dropBackground": "#5b607899",
+    "terminal.selectionBackground": "#5b6078",
+    "terminalCursor.background": "#24273a",
+    "terminalCursor.foreground": "#f4dbd6",
+    "titleBar.activeBackground": "#181926",
+    "titleBar.activeForeground": "#cad3f5",
+    "titleBar.inactiveBackground": "#181926",
+    "titleBar.inactiveForeground": "#cad3f57f",
+    "titleBar.border": "#00000000",
+    "welcomePage.tileBackground": "#1e2030",
+    "welcomePage.progress.background": "#181926",
+    "welcomePage.progress.foreground": "#c6a0f6",
+    "walkThrough.embeddedEditorBackground": "#24273a4c",
+    "symbolIcon.textForeground": "#cad3f5",
+    "symbolIcon.arrayForeground": "#f5a97f",
+    "symbolIcon.booleanForeground": "#c6a0f6",
+    "symbolIcon.classForeground": "#eed49f",
+    "symbolIcon.colorForeground": "#f5bde6",
+    "symbolIcon.constantForeground": "#f5a97f",
+    "symbolIcon.constructorForeground": "#b7bdf8",
+    "symbolIcon.enumeratorForeground": "#eed49f",
+    "symbolIcon.enumeratorMemberForeground": "#eed49f",
+    "symbolIcon.eventForeground": "#f5bde6",
+    "symbolIcon.fieldForeground": "#cad3f5",
+    "symbolIcon.fileForeground": "#c6a0f6",
+    "symbolIcon.folderForeground": "#c6a0f6",
+    "symbolIcon.functionForeground": "#8aadf4",
+    "symbolIcon.interfaceForeground": "#eed49f",
+    "symbolIcon.keyForeground": "#8bd5ca",
+    "symbolIcon.keywordForeground": "#c6a0f6",
+    "symbolIcon.methodForeground": "#8aadf4",
+    "symbolIcon.moduleForeground": "#cad3f5",
+    "symbolIcon.namespaceForeground": "#eed49f",
+    "symbolIcon.nullForeground": "#ee99a0",
+    "symbolIcon.numberForeground": "#f5a97f",
+    "symbolIcon.objectForeground": "#eed49f",
+    "symbolIcon.operatorForeground": "#8bd5ca",
+    "symbolIcon.packageForeground": "#f0c6c6",
+    "symbolIcon.propertyForeground": "#ee99a0",
+    "symbolIcon.referenceForeground": "#eed49f",
+    "symbolIcon.snippetForeground": "#f0c6c6",
+    "symbolIcon.stringForeground": "#a6da95",
+    "symbolIcon.structForeground": "#8bd5ca",
+    "symbolIcon.typeParameterForeground": "#ee99a0",
+    "symbolIcon.unitForeground": "#cad3f5",
+    "symbolIcon.variableForeground": "#cad3f5",
+    "charts.foreground": "#cad3f5",
+    "charts.lines": "#b8c0e0",
+    "charts.red": "#ed8796",
+    "charts.blue": "#8aadf4",
+    "charts.yellow": "#eed49f",
+    "charts.orange": "#f5a97f",
+    "charts.green": "#a6da95",
+    "charts.purple": "#c6a0f6",
+    "errorLens.errorBackground": "#ed879626",
+    "errorLens.errorMessageBackground": "#ed879626",
+    "errorLens.errorBackgroundLight": "#ed879626",
+    "errorLens.errorForeground": "#ed8796",
+    "errorLens.errorForegroundLight": "#ed8796",
+    "errorLens.warningBackground": "#f5a97f26",
+    "errorLens.warningMessageBackground": "#f5a97f26",
+    "errorLens.warningBackgroundLight": "#f5a97f26",
+    "errorLens.warningForeground": "#f5a97f",
+    "errorLens.warningForegroundLight": "#f5a97f",
+    "errorLens.infoBackground": "#8aadf426",
+    "errorLens.infoMessageBackground": "#8aadf426",
+    "errorLens.infoBackgroundLight": "#8aadf426",
+    "errorLens.infoForeground": "#8aadf4",
+    "errorLens.infoForegroundLight": "#8aadf4",
+    "errorLens.hintBackground": "#a6da9526",
+    "errorLens.hintMessageBackground": "#a6da9526",
+    "errorLens.hintBackgroundLight": "#a6da9526",
+    "errorLens.hintForeground": "#a6da95",
+    "errorLens.hintForegroundLight": "#a6da95",
+    "errorLens.statusBarIconErrorForeground": "#ed8796",
+    "errorLens.statusBarIconWarningForeground": "#f5a97f",
+    "errorLens.statusBarErrorForeground": "#ed8796",
+    "errorLens.statusBarWarningForeground": "#f5a97f",
+    "errorLens.statusBarInfoForeground": "#8aadf4",
+    "errorLens.statusBarHintForeground": "#a6da95",
+    "editorBracketHighlight.foreground1": "#ed8796",
+    "editorBracketHighlight.foreground2": "#f5a97f",
+    "editorBracketHighlight.foreground3": "#eed49f",
+    "editorBracketHighlight.foreground4": "#a6da95",
+    "editorBracketHighlight.foreground5": "#7dc4e4",
+    "editorBracketHighlight.foreground6": "#c6a0f6",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#ee99a0"
+  }
+}

--- a/shiki/shiki-mocha-theme.json
+++ b/shiki/shiki-mocha-theme.json
@@ -1,0 +1,2798 @@
+{
+  "name": "Catppuccin Mocha",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "semanticTokenColors": {
+    "enumMember": {
+      "foreground": "#89dceb"
+    },
+    "variable.constant": {
+      "foreground": "#f9e2af"
+    },
+    "variable.defaultLibrary": {
+      "foreground": "#fab387"
+    }
+  },
+  "tokenColors": [
+    {
+      "name": "All variable",
+      "scope": ["variable.language", "variable.other"],
+      "settings": {
+        "foreground": "#f2cdcd"
+      }
+    },
+    {
+      "name": "All function",
+      "scope": ["entity.name.function", "support.function"],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All parameter",
+      "scope": [
+        "variable.parameter.function",
+        "variable.parameter.function-call"
+      ],
+      "settings": {
+        "foreground": "#f5c2e7",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All numeric",
+      "scope": ["constant.numeric.decimal", "constant.numeric.integer"],
+      "settings": {
+        "foreground": "#fab387",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All types",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "All conditionals",
+      "scope": [
+        "keyword.control",
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All punctuation brackets",
+      "scope": [
+        "punctuation.brackets",
+        "punctuation.section",
+        "punctuation.definition"
+      ],
+      "settings": {
+        "foreground": "#7f849c"
+      }
+    },
+    {
+      "name": "All punctuation delimiters",
+      "scope": "punctuation.semi",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "All namespace",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#f5e0dc"
+      }
+    },
+    {
+      "name": "All operators",
+      "scope": [
+        "keyword.operator.comparison",
+        "keyword.operator.assignment",
+        "keyword.operator.arrow.skinny",
+        "keyword.operator.math",
+        "keyword.operator.key-value",
+        "keyword.operator.misc",
+        "keyword.operator.namespace"
+      ],
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "All built-in constants",
+      "scope": "constant.language",
+      "settings": {
+        "foreground": "#b4befe",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "All constants",
+      "scope": "constant.other",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "JSON quoted string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "JSON punctuation string",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "JSON punct structure",
+      "scope": [
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json",
+        "source.json meta.structure.array.json > value.json > string.quoted.json",
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation",
+        "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+      ],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "JSON property name",
+      "scope": "support.type.property-name.json.comments",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "JSON constants",
+      "scope": "constant.language.json.comments",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "JSON punctuation",
+      "scope": [
+        "punctuation.separator.dictionary.pair.json.comments",
+        "punctuation.separator.array.json.comments"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "JSON brackets",
+      "scope": [
+        "punctuation.definition.dictionary.begin.json.comments",
+        "punctuation.definition.dictionary.end.json.comments",
+        "punctuation.definition.array.begin.json.comments",
+        "punctuation.definition.array.end.json.comments"
+      ],
+      "settings": {
+        "foreground": "#9399b2"
+      }
+    },
+    {
+      "name": "JSON constant language",
+      "scope": [
+        "source.json meta.structure.dictionary.json > constant.language.json",
+        "source.json meta.structure.array.json > constant.language.json"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "JSON property name [VSCODE-CUSTOM]",
+      "scope": "support.type.property-name.json",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "unison punctuation",
+      "scope": [
+        "punctuation.definition.delayed.unison",
+        "punctuation.definition.list.begin.unison",
+        "punctuation.definition.list.end.unison",
+        "punctuation.definition.ability.begin.unison",
+        "punctuation.definition.ability.end.unison",
+        "punctuation.operator.assignment.as.unison",
+        "punctuation.separator.pipe.unison",
+        "punctuation.separator.delimiter.unison",
+        "punctuation.definition.hash.unison"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "haskell variable generic-type",
+      "scope": "variable.other.generic-type.haskell",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "haskell storage type",
+      "scope": "storage.type.haskell",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "support.variable.magic.python",
+      "scope": "support.variable.magic.python",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "punctuation.separator.parameters.python",
+      "scope": [
+        "punctuation.separator.period.python",
+        "punctuation.separator.element.python",
+        "punctuation.parenthesis.begin.python",
+        "punctuation.parenthesis.end.python"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.self.python",
+      "scope": "variable.parameter.function.language.special.self.python",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Rust modifier",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Rust types",
+      "scope": "entity.name.type.rust",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Rust functions std",
+      "scope": "support.function.std.rust",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Rust functions",
+      "scope": "entity.name.function.rust",
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust function keyword",
+      "scope": "keyword.other.fn.rust",
+      "settings": {
+        "foreground": "#eba0ac"
+      }
+    },
+    {
+      "name": "Rust conditionals",
+      "scope": "keyword.control.rust",
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": "bold italic"
+      }
+    },
+    {
+      "name": "Rust punctuation brackets",
+      "scope": [
+        "punctuation.brackets.curly.rust",
+        "punctuation.brackets.round.rust",
+        "punctuation.brackets.square.rust",
+        "punctuation.brackets.attribute.rust"
+      ],
+      "settings": {
+        "foreground": "#7f849c"
+      }
+    },
+    {
+      "name": "Rust namespace",
+      "scope": "entity.name.namespace.rust",
+      "settings": {
+        "foreground": "#f5e0dc"
+      }
+    },
+    {
+      "name": "Rust punctuation delimiters",
+      "scope": "punctuation.semi.rust",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Rust operators",
+      "scope": [
+        "keyword.operator.comparison.rust",
+        "keyword.operator.assignment.equal.rust",
+        "keyword.operator.arrow.skinny.rust",
+        "keyword.operator.math.rust",
+        "keyword.operator.key-value.rust",
+        "keyword.operator.misc.rust"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Rust operator namespaces",
+      "scope": "keyword.operator.namespace.rust",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Rust definition attributes",
+      "scope": [
+        "punctuation.definition.attribute.rust",
+        "keyword.operator.attribute.inner.rust"
+      ],
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Rust math logic",
+      "scope": "constant.numeric.decimal.rust",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Rust constants",
+      "scope": "support.constant.core.rust",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Rust entity name",
+      "scope": "entity.name.lifetime.rust",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Rust variable",
+      "scope": ["variable.language.rust", "variable.other.rust"],
+      "settings": {
+        "foreground": "#cdd6f4",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Rust misc operators",
+      "scope": "keyword.operator.misc.rust",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Rust sigil operator",
+      "scope": "keyword.operator.sigil.rust",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Lua operators",
+      "scope": "keyword.operator.lua",
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua numeric",
+      "scope": "constant.numeric.integer.lua",
+      "settings": {
+        "foreground": "#fab387",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Lua other vars",
+      "scope": "variable.other.lua",
+      "settings": {
+        "foreground": "#b4befe",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Lua brackets",
+      "scope": [
+        "punctuation.definition.parameters.end.lua",
+        "punctuation.definition.parameters.begin.lua"
+      ],
+      "settings": {
+        "foreground": "#7f849c"
+      }
+    },
+    {
+      "name": "C++ Punct Delimiters",
+      "scope": "punctuation.terminator.statement.cpp",
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ Variables",
+      "scope": "variable.other.local.cpp",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "C++ Operators",
+      "scope": [
+        "punctuation.separator.scope-resolution.cpp",
+        "punctuation.separator.scope-resolution.namespace.alias.cpp",
+        "punctuation.separator.scope-resolution.namespace.using.cpp"
+      ],
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ function",
+      "scope": "meta.function.c,meta.function.cpp",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "C++ constructor/destructor",
+      "scope": [
+        "entity.name.function.definition.special.constructor",
+        "entity.name.function.definition.special.member.destructor"
+      ],
+      "settings": {
+        "foreground": "#b4befe"
+      }
+    },
+    {
+      "name": "C++ directive",
+      "scope": [
+        "keyword.control.directive",
+        "keyword.other.using.directive",
+        "punctuation.definition.directive"
+      ],
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ ifdef directive",
+      "scope": [
+        "keyword.control.directive.conditional.ifdef.cpp",
+        "keyword.control.directive.else.cpp",
+        "keyword.control.directive.else.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp",
+        "keyword.control.directive.conditional.ifdef.cpp punctuation.definition.directive.cpp",
+        "keyword.control.directive.endif.cpp punctuation.definition.directive.cpp"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "C++ misc",
+      "scope": [
+        "entity.name.other.preprocessor.macro.predefined.probably",
+        "entity.name.scope-resolution.cpp"
+      ],
+      "settings": {
+        "foreground": "#f5e0dc",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "C++ pointer/reference",
+      "scope": [
+        "storage.modifier.pointer.cpp",
+        "storage.modifier.reference.cpp"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "C++ loop/conditional",
+      "scope": [
+        "keyword.control.for",
+        "keyword.control.while",
+        "keyword.control.if",
+        "keyword.control.else",
+        "keyword.control.switch",
+        "keyword.control.case"
+      ],
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C++ return",
+      "scope": "keyword.control.return",
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "C++ block",
+      "scope": [
+        "punctuation.section.block.begin.bracket.curly.cpp",
+        "punctuation.section.block.end.bracket.curly.cpp",
+        "punctuation.terminator.statement.c",
+        "punctuation.section.block.begin.bracket.curly.c",
+        "punctuation.section.block.end.bracket.curly.c",
+        "punctuation.section.parens.begin.bracket.round.c",
+        "punctuation.section.parens.end.bracket.round.c",
+        "punctuation.section.parameters.begin.bracket.round.c",
+        "punctuation.section.parameters.end.bracket.round.c"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "C++ storage type modifier",
+      "scope": "storage.type.built-in.primitive.cpp",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "C++/C#",
+      "scope": [
+        "entity.name.label.cs",
+        "entity.name.scope-resolution.function.call",
+        "entity.name.scope-resolution.function.definition"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "support.constant.edge",
+      "scope": "support.constant.edge",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "regexp constant character-class",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "regexp operator.quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "punctuation.definition",
+      "scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": "comment markup.link",
+      "settings": {
+        "foreground": "#6c7086"
+      }
+    },
+    {
+      "name": "markup diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "diff",
+      "scope": [
+        "meta.diff.header.from-file",
+        "meta.diff.header.to-file",
+        "punctuation.definition.from-file.diff",
+        "punctuation.definition.to-file.diff"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "inserted.diff",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "deleted.diff",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Quote multi",
+      "scope": [
+        "string.quoted.docstring.multi",
+        "string.quoted.multi",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.begin.python",
+        "source.python string.quoted.multi.python punctuation.definition.string.end.python",
+        "markup.fenced_code.block"
+      ],
+      "settings": {
+        "foreground": "#a6e3a1",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "js/ts punctuation separator key-value",
+      "scope": "punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "js/ts import keyword",
+      "scope": "keyword.operator.expression.import",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "math js/ts",
+      "scope": "support.constant.math",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "math property js/ts",
+      "scope": "support.constant.property.math",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "js/ts variable.other.constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "java type",
+      "scope": [
+        "storage.type.annotation.java",
+        "storage.type.object.array.java"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "java source",
+      "scope": "source.java",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": [
+        "punctuation.section.block.begin.java",
+        "punctuation.section.block.end.java",
+        "punctuation.definition.method-parameters.begin.java",
+        "punctuation.definition.method-parameters.end.java",
+        "meta.method.identifier.java",
+        "punctuation.section.method.begin.java",
+        "punctuation.section.method.end.java",
+        "punctuation.terminator.java",
+        "punctuation.section.class.begin.java",
+        "punctuation.section.class.end.java",
+        "punctuation.section.inner-class.begin.java",
+        "punctuation.section.inner-class.end.java",
+        "meta.method-call.java",
+        "punctuation.section.class.begin.bracket.curly.java",
+        "punctuation.section.class.end.bracket.curly.java",
+        "punctuation.section.method.begin.bracket.curly.java",
+        "punctuation.section.method.end.bracket.curly.java",
+        "punctuation.separator.period.java",
+        "punctuation.bracket.angle.java",
+        "punctuation.definition.annotation.java",
+        "meta.method.body.java"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "meta.method.java",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "java variable.name",
+      "scope": "meta.definition.variable.name.java",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "operator logical",
+      "scope": ["keyword.operator.logical", "keyword.operator.ternary"],
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "operator bitwise",
+      "scope": "keyword.operator.bitwise",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "support.constant.property-value.scss",
+      "scope": [
+        "support.constant.property-value.scss",
+        "support.constant.property-value.css"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": [
+        "keyword.operator.css",
+        "keyword.operator.scss",
+        "keyword.operator.less"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "css color standard name",
+      "scope": [
+        "support.constant.color.w3c-standard-color-name.css",
+        "support.constant.color.w3c-standard-color-name.scss"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "css comma",
+      "scope": "punctuation.separator.list.comma.css",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "css attribute-name.id",
+      "scope": "support.constant.color.w3c-standard-color-name.css",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "css property-name",
+      "scope": "support.type.vendored.property-name.css",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "js/ts module",
+      "scope": [
+        "support.module.node",
+        "support.type.object.module",
+        "support.module.node"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "entity.name.type.module",
+      "scope": "entity.name.type.module",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "js variable readwrite",
+      "scope": [
+        "variable.other.readwrite",
+        "meta.object-literal.key",
+        "support.variable.property",
+        "support.variable.object.process",
+        "support.variable.object.node"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "js/ts json",
+      "scope": "support.constant.json",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "js/ts Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.ternary",
+        "keyword.operator.optional",
+        "keyword.operator.expression.keyof"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "js/ts console",
+      "scope": "support.type.object.console",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "js/ts support.variable.property.process",
+      "scope": "support.variable.property.process",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "js console function",
+      "scope": "entity.name.function,support.function.console",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "operator",
+      "scope": "keyword.operator.delete",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "js dom",
+      "scope": "support.type.object.dom",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "js dom variable",
+      "scope": ["support.variable.dom", "support.variable.property.dom"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": [
+        "keyword.operator.arithmetic",
+        "keyword.operator.comparison",
+        "keyword.operator.decrement",
+        "keyword.operator.increment",
+        "keyword.operator.relational"
+      ],
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "C operators",
+      "scope": [
+        "keyword.operator.c",
+        "keyword.operator.increment.c",
+        "keyword.operator.decrement.c",
+        "keyword.operator.bitwise.shift.c",
+        "keyword.operator.cpp",
+        "keyword.operator.increment.cpp",
+        "keyword.operator.decrement.cpp",
+        "keyword.operator.bitwise.shift.cpp"
+      ],
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Other punctuation .c",
+      "scope": ["punctuation.separator.c", "punctuation.separator.cpp"],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "C type posix-reserved",
+      "scope": [
+        "support.type.posix-reserved.c",
+        "support.type.posix-reserved.cpp"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "keyword.operator.sizeof.c",
+      "scope": ["keyword.operator.sizeof.c", "keyword.operator.sizeof.cpp"],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "python type",
+      "scope": "support.type.python",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "python block",
+      "scope": [
+        "punctuation.definition.arguments.begin.python",
+        "punctuation.definition.arguments.end.python",
+        "punctuation.separator.arguments.python",
+        "punctuation.definition.list.begin.python",
+        "punctuation.definition.list.end.python"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "python function-call.generic",
+      "scope": "meta.function-call.generic.python",
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#89dceb",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Java Variables",
+      "scope": "token.variable.parameter.java",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Java Imports",
+      "scope": "import.storage.java",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package.keyword",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Functions",
+      "scope": [
+        "entity.name.function",
+        "meta.require",
+        "support.function.any-method",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "entity.name.type.namespace",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "support.class, entity.name.type.class",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": "entity.name.class.identifier.namespace.type",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "variable.other.class.js",
+        "variable.other.class.ts"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Class name php",
+      "scope": "variable.other.class.php",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Type Name",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Control Elements",
+      "scope": "control.elements, keyword.operator.less",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Methods",
+      "scope": "keyword.other.special-method",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Storage JS TS",
+      "scope": "token.storage",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete, In, Of, Instanceof, New, Typeof, Void",
+      "scope": [
+        "keyword.operator.expression.delete",
+        "keyword.operator.expression.in",
+        "keyword.operator.expression.of",
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.expression.typeof",
+        "keyword.operator.expression.void"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Java Storage",
+      "scope": "token.storage.type.java",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Support",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.property-value",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.font-name",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Meta tag",
+      "scope": "meta.tag",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": "string",
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "Inherited Class",
+      "scope": "entity.other.inherited-class",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Constant other symbol",
+      "scope": "constant.other.symbol",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Integers",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "constant",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "punctuation.definition.constant",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Tags",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Attributes",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Attribute IDs",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Attribute class",
+      "scope": "entity.other.attribute-name.class.css",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "SCSS variables",
+      "scope": "variable.scss",
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Selector",
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Units",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "markup.bold,todo.bold",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "punctuation.definition.bold",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "markup Italic",
+      "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "emphasis md",
+      "scope": "emphasis md",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "punctuation.definition.list.begin.markdown",
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "punctuation.definition.list.markdown",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "beginning.punctuation.definition.list.markdown",
+      "scope": ["beginning.punctuation.definition.list.markdown"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Regular Expressions",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Escape Characters",
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded, variable.interpolation",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "illegal, deprecated",
+      "scope": "invalid.illegal, invalid.deprecated",
+      "settings": {
+        "foreground": "#6c7086",
+        "fontStyle": "strikethrough"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal.bad-ampersand.html",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Broken",
+      "scope": "invalid.broken",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Unimplemented",
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "foreground": "#a6adc8"
+      }
+    },
+    {
+      "name": "laravel blade tag",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "laravel blade @",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "use statement for other classes",
+      "scope": [
+        "support.other.namespace.use.php",
+        "support.other.namespace.use-as.php",
+        "support.other.namespace.php",
+        "entity.other.alias.php",
+        "meta.interface.php"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "error suppression",
+      "scope": "keyword.operator.error-control.php",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "php instanceof",
+      "scope": "keyword.operator.type.php",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "style double quoted array index normal begin",
+      "scope": "punctuation.section.array.begin.php",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "style double quoted array index normal end",
+      "scope": "punctuation.section.array.end.php",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "php illegal.non-null-typehinted",
+      "scope": "invalid.illegal.non-null-typehinted.php",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "php types",
+      "scope": [
+        "storage.type.php",
+        "meta.other.type.phpdoc.php",
+        "keyword.other.type.php",
+        "keyword.other.array.phpdoc.php"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "php call-function",
+      "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "php function-resets",
+      "scope": [
+        "punctuation.definition.parameters.begin.bracket.round.php",
+        "punctuation.definition.parameters.end.bracket.round.php",
+        "punctuation.separator.delimiter.php",
+        "punctuation.section.scope.begin.php",
+        "punctuation.section.scope.end.php",
+        "punctuation.terminator.expression.php",
+        "punctuation.definition.arguments.begin.bracket.round.php",
+        "punctuation.definition.arguments.end.bracket.round.php",
+        "punctuation.definition.storage-type.begin.bracket.round.php",
+        "punctuation.definition.storage-type.end.bracket.round.php",
+        "punctuation.definition.array.begin.bracket.round.php",
+        "punctuation.definition.array.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.round.php",
+        "punctuation.definition.end.bracket.round.php",
+        "punctuation.definition.begin.bracket.curly.php",
+        "punctuation.definition.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php",
+        "punctuation.definition.section.switch-block.start.bracket.curly.php",
+        "punctuation.definition.section.switch-block.begin.bracket.curly.php",
+        "punctuation.definition.section.switch-block.end.bracket.curly.php"
+      ],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": [
+        "support.constant.ext.php",
+        "support.constant.std.php",
+        "support.constant.core.php",
+        "support.constant.parser-token.php"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "php goto",
+      "scope": "entity.name.goto-label.php,support.other.php",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "php logical/bitwise operator",
+      "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "php regexp operator",
+      "scope": "keyword.operator.regexp.php",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "php comparison",
+      "scope": "keyword.operator.comparison.php",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "php heredoc/nowdoc",
+      "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "python function decorator @",
+      "scope": "meta.function.decorator.python",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": [
+        "support.token.decorator.python",
+        "meta.function.decorator.identifier.python"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "parameter function js/ts",
+      "scope": "function.parameter",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "brace function",
+      "scope": "function.brace",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "parameter function ruby cs",
+      "scope": ["function.parameter.ruby", "function.parameter.cs"],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "constant.language.symbol.ruby",
+      "scope": "constant.language.symbol.ruby",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "rgb-value",
+      "scope": "rgb-value",
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "rgb value",
+      "scope": "inline-color-decoration rgb-value",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "rgb value less",
+      "scope": "less rgb-value",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "sass selector",
+      "scope": "selector.sass",
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "ts primitive/builtin types",
+      "scope": [
+        "support.type.primitive.ts",
+        "support.type.builtin.ts",
+        "support.type.primitive.tsx",
+        "support.type.builtin.tsx"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "block scope",
+      "scope": "block.scope.end,block.scope.begin",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "cs storage type",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "cs local variable",
+      "scope": "entity.name.variable.local.cs",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": ["meta.template.expression"],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Import module JS",
+      "scope": ["keyword.operator.module"],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "js Flowtype",
+      "scope": ["support.type.type.flowtype"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "js Flow",
+      "scope": ["support.type.primitive"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "js class prop",
+      "scope": ["meta.property.object"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "js func parameter",
+      "scope": ["variable.parameter.function.js"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "js template literals begin",
+      "scope": ["keyword.other.template.begin"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "js template literals end",
+      "scope": ["keyword.other.template.end"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "js template literals variable braces begin",
+      "scope": ["keyword.other.substitution.begin"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "js template literals variable braces end",
+      "scope": ["keyword.other.substitution.end"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.arithmetic.go",
+        "keyword.operator.address.go"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "Go package name",
+      "scope": ["entity.name.package.go"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Go import statement",
+      "scope": "keyword.import.go",
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "elm prelude",
+      "scope": ["support.type.prelude.elm"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "elm constant",
+      "scope": ["support.constant.elm"],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": ["punctuation.quasi.element"],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": ["constant.character.entity"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+      "scope": [
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.pseudo-class"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": ["entity.global.clojure"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": ["meta.symbol.clojure"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": ["constant.keyword.clojure"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": ["meta.arguments.coffee", "variable.parameter.function.coffee"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": ["source.ini"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "Shell definition variables",
+      "scope": ["punctuation.definition.variable.shell"],
+      "settings": {
+        "foreground": "#7f849c"
+      }
+    },
+    {
+      "name": "Shell logical operators",
+      "scope": ["keyword.operator.logical.shell"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Shell clauses",
+      "scope": ["meta.scope.case-clause-body.shell"],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Shell funcs",
+      "scope": ["meta.scope.group.shell"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Shell interpolated cmds",
+      "scope": ["string.interpolated.dollar.shell"],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Shell interpolated strings",
+      "scope": ["string.quoted.single.shell"],
+      "settings": {
+        "foreground": "#b4befe"
+      }
+    },
+    {
+      "name": "Shell pipe symbol",
+      "scope": ["keyword.operator.pipe.shell"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Shell group definition",
+      "scope": ["punctuation.definition.group.shell"],
+      "settings": {
+        "foreground": "#7f849c"
+      }
+    },
+    {
+      "name": "Shell conditionals",
+      "scope": ["keyword.control.shell"],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Shell operators and punct delimiters",
+      "scope": ["keyword.operator.list.shell"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Shell parenthesis",
+      "scope": ["punctuation.definition.logical-expression.shell"],
+      "settings": {
+        "foreground": "#7f849c"
+      }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": ["meta.scope.prerequisites.makefile"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": ["source.makefile"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": ["storage.modifier.import.groovy"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": ["meta.method.groovy"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": ["meta.definition.variable.name.groovy"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": ["meta.definition.class.inherited.classes.groovy"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": ["support.variable.semantic.hlsl"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "SQL Variables",
+      "scope": ["text.variable", "text.bracketed"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "types",
+      "scope": ["support.type.swift", "support.type.vb.asp"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "heading 1, keyword",
+      "scope": ["entity.name.function.xi"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "heading 2, callable",
+      "scope": ["entity.name.class.xi"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "heading 3, property",
+      "scope": ["constant.character.character-class.regexp.xi"],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "heading 4, type, class, interface",
+      "scope": ["constant.regexp.xi"],
+      "settings": {
+        "foreground": "#f38ba8"
+      }
+    },
+    {
+      "name": "heading 5, enums, preprocessor, constant, decorator",
+      "scope": ["keyword.control.xi"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "heading 6, number",
+      "scope": ["invalid.xi"],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "string",
+      "scope": ["beginning.punctuation.definition.quote.markdown.xi"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "comments",
+      "scope": ["beginning.punctuation.definition.list.markdown.xi"],
+      "settings": {
+        "foreground": "#6c7086"
+      }
+    },
+    {
+      "name": "link",
+      "scope": ["constant.character.xi"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "accent",
+      "scope": ["accent.xi"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "wikiword",
+      "scope": ["wikiword.xi"],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "language operators like '+', '-' etc",
+      "scope": ["constant.other.color.rgb-value.xi"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "elements to dim",
+      "scope": ["punctuation.definition.tag.xi"],
+      "settings": {
+        "foreground": "#6c7086"
+      }
+    },
+    {
+      "name": "Markdown underscore-style headers",
+      "scope": [
+        "entity.name.label.cs",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.setext.2.markdown"
+      ],
+      "settings": {
+        "foreground": "#94e2d5"
+      }
+    },
+    {
+      "name": "meta.brace.square",
+      "scope": [" meta.brace.square"],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": "comment, punctuation.definition.comment",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#6c7086"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": {
+        "foreground": "#6c7086"
+      }
+    },
+    {
+      "name": "punctuation.definition.block.sequence.item.yaml",
+      "scope": "punctuation.definition.block.sequence.item.yaml",
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "scope": ["constant.language.symbol.elixir"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "js/ts italic",
+      "scope": [
+        "entity.other.attribute-name.js",
+        "entity.other.attribute-name.ts",
+        "entity.other.attribute-name.jsx",
+        "entity.other.attribute-name.tsx",
+        "variable.parameter",
+        "variable.language.super"
+      ],
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "comment",
+      "scope": "comment.line.double-slash,comment.block.documentation",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword import",
+      "scope": "keyword.control.import.python",
+      "settings": {
+        "foreground": "#94e2d5",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "python keyword flow",
+      "scope": "keyword.control.flow.python",
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "python storage type",
+      "scope": "storage.type.function.python",
+      "settings": {
+        "foreground": "#eba0ac",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "markup.italic.markdown",
+      "scope": "markup.italic.markdown",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "invalid.deprecated.line-too-long.git-commit",
+      "scope": "invalid.deprecated.line-too-long.git-commit",
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "underline"
+      }
+    }
+  ],
+  "colors": {
+    "focusBorder": "#00000000",
+    "foreground": "#cdd6f4",
+    "disabledForeground": "#a6adc8",
+    "widget.shadow": "#1818257f",
+    "selection.background": "#585b70",
+    "descriptionForeground": "#cdd6f4",
+    "errorForeground": "#f38ba8",
+    "icon.foreground": "#cba6f7",
+    "sash.hoverBorder": "#cba6f7",
+    "window.activeBorder": "#00000000",
+    "window.inactiveBorder": "#00000000",
+    "textBlockQuote.background": "#181825",
+    "textBlockQuote.border": "#11111b",
+    "textCodeBlock.background": "#1e1e2e",
+    "textLink.activeForeground": "#89dceb",
+    "textLink.foreground": "#89b4fa",
+    "textPreformat.foreground": "#cdd6f4",
+    "textSeparator.foreground": "#cba6f7",
+    "activityBar.background": "#11111b",
+    "activityBar.foreground": "#cba6f7",
+    "activityBar.dropBar": "#585b7099",
+    "activityBar.inactiveForeground": "#6c7086",
+    "activityBar.border": "#00000000",
+    "activityBarBadge.background": "#cba6f7",
+    "activityBarBadge.foreground": "#11111b",
+    "activityBar.activeBorder": "#00000000",
+    "activityBar.activeBackground": "#00000000",
+    "activityBar.activeFocusBorder": "#00000000",
+    "badge.background": "#45475a",
+    "badge.foreground": "#cdd6f4",
+    "breadcrumb.activeSelectionForeground": "#cba6f7",
+    "breadcrumb.background": "#181825",
+    "breadcrumb.focusForeground": "#cba6f7",
+    "breadcrumb.foreground": "#cdd6f4cc",
+    "breadcrumbPicker.background": "#181825",
+    "button.background": "#cba6f7",
+    "button.foreground": "#11111b",
+    "button.border": "#00000000",
+    "button.separator": "#00000000",
+    "button.hoverBackground": "#dfbaff",
+    "button.secondaryForeground": "#cdd6f4",
+    "button.secondaryBackground": "#585b70",
+    "button.secondaryHoverBackground": "#6c6f84",
+    "checkbox.background": "#45475a",
+    "checkbox.border": "#00000000",
+    "checkbox.foreground": "#cba6f7",
+    "dropdown.background": "#181825",
+    "dropdown.listBackground": "#585b70",
+    "dropdown.border": "#cba6f7",
+    "dropdown.foreground": "#cdd6f4",
+    "debugToolBar.background": "#11111b",
+    "debugToolBar.border": "#00000000",
+    "debugExceptionWidget.background": "#11111b",
+    "debugExceptionWidget.border": "#cba6f7",
+    "debugTokenExpression.number": "#fab387",
+    "debugTokenExpression.boolean": "#cba6f7",
+    "debugTokenExpression.string": "#a6e3a1",
+    "debugTokenExpression.error": "#f38ba8",
+    "debugIcon.breakpointForeground": "#f38ba8",
+    "debugIcon.breakpointDisabledForeground": "#f38ba899",
+    "debugIcon.breakpointUnverifiedForeground": "#1e1e2e",
+    "debugIcon.breakpointCurrentStackframeForeground": "#585b70",
+    "debugIcon.breakpointStackframeForeground": "#585b70",
+    "debugIcon.startForeground": "#a6e3a1",
+    "debugIcon.pauseForeground": "#89b4fa",
+    "debugIcon.stopForeground": "#f38ba8",
+    "debugIcon.disconnectForeground": "#585b70",
+    "debugIcon.restartForeground": "#94e2d5",
+    "debugIcon.stepOverForeground": "#cba6f7",
+    "debugIcon.stepIntoForeground": "#cdd6f4",
+    "debugIcon.stepOutForeground": "#cdd6f4",
+    "debugIcon.continueForeground": "#a6e3a1",
+    "debugIcon.stepBackForeground": "#585b70",
+    "debugConsole.infoForeground": "#89b4fa",
+    "debugConsole.warningForeground": "#fab387",
+    "debugConsole.errorForeground": "#f38ba8",
+    "debugConsole.sourceForeground": "#f5e0dc",
+    "debugConsoleInputIcon.foreground": "#cdd6f4",
+    "diffEditor.border": "#585b70",
+    "diffEditor.insertedTextBackground": "#a6e3a119",
+    "diffEditor.removedTextBackground": "#f38ba819",
+    "diffEditor.insertedLineBackground": "#a6e3a126",
+    "diffEditor.removedLineBackground": "#f38ba826",
+    "diffEditor.diagonalFill": "#585b7099",
+    "diffEditorOverview.insertedForeground": "#a6e3a1cc",
+    "diffEditorOverview.removedForeground": "#f38ba8cc",
+    "editor.background": "#1e1e2e",
+    "editor.findMatchBackground": "#585b70",
+    "editor.findMatchBorder": "#cba6f766",
+    "editor.findMatchHighlightBackground": "#fab38759",
+    "editor.findMatchHighlightBorder": "#00000000",
+    "editor.findRangeHighlightBackground": "#585b704c",
+    "editor.findRangeHighlightBorder": "#00000000",
+    "editor.foldBackground": "#89dceb3f",
+    "editor.foreground": "#cdd6f4",
+    "editor.hoverHighlightBackground": "#89dceb3f",
+    "editor.inactiveSelectionBackground": "#00000000",
+    "editor.lineHighlightBackground": "#cdd6f411",
+    "editor.lineHighlightBorder": "#1e1e2e",
+    "editor.rangeHighlightBackground": "#89dceb3f",
+    "editor.rangeHighlightBorder": "#00000000",
+    "editor.selectionBackground": "#585b70",
+    "editor.selectionHighlightBackground": "#9399b266",
+    "editor.selectionHighlightBorder": "#89dceb33",
+    "editor.wordHighlightBackground": "#585b70b2",
+    "editor.wordHighlightStrongBackground": "#585b707f",
+    "editorBracketMatch.background": "#9399b219",
+    "editorBracketMatch.border": "#9399b2",
+    "editorCodeLens.foreground": "#7f849c",
+    "editorCursor.background": "#1e1e2e",
+    "editorCursor.foreground": "#f5e0dc",
+    "editorError.background": "#00000000",
+    "editorError.border": "#00000000",
+    "editorError.foreground": "#f38ba8",
+    "editorGroup.border": "#585b70",
+    "editorGroup.dropBackground": "#585b7099",
+    "editorGroup.emptyBackground": "#1e1e2e",
+    "editorGroupHeader.tabsBackground": "#11111b",
+    "editorGutter.addedBackground": "#a6e3a1",
+    "editorGutter.background": "#1e1e2e",
+    "editorGutter.commentRangeForeground": "#9399b2",
+    "editorGutter.deletedBackground": "#f38ba8",
+    "editorGutter.foldingControlForeground": "#9399b2",
+    "editorGutter.modifiedBackground": "#89dceb",
+    "editorHoverWidget.background": "#181825",
+    "editorHoverWidget.border": "#585b70",
+    "editorHoverWidget.foreground": "#cdd6f4",
+    "editorIndentGuide.activeBackground": "#585b70",
+    "editorIndentGuide.background": "#45475a",
+    "editorInfo.background": "#00000000",
+    "editorInfo.border": "#00000000",
+    "editorInfo.foreground": "#89b4fa",
+    "editorInlayHint.foreground": "#585b70",
+    "editorInlayHint.background": "#181825bf",
+    "editorInlayHint.typeForeground": "#bac2de",
+    "editorInlayHint.typeBackground": "#181825bf",
+    "editorInlayHint.parameterForeground": "#a6adc8",
+    "editorInlayHint.parameterBackground": "#181825bf",
+    "editorLineNumber.activeForeground": "#cba6f7",
+    "editorLineNumber.foreground": "#7f849c",
+    "editorLink.activeForeground": "#cba6f7",
+    "editorMarkerNavigation.background": "#181825",
+    "editorMarkerNavigationError.background": "#f38ba8",
+    "editorMarkerNavigationInfo.background": "#89b4fa",
+    "editorMarkerNavigationWarning.background": "#f9e2af",
+    "editorOverviewRuler.background": "#181825",
+    "editorOverviewRuler.border": "#cdd6f411",
+    "editorRuler.foreground": "#585b70",
+    "editor.stackFrameHighlightBackground": "#f9e2af26",
+    "editor.focusedStackFrameHighlightBackground": "#a6e3a126",
+    "editorStickyScrollHover.background": "#313244",
+    "editorSuggestWidget.background": "#181825",
+    "editorSuggestWidget.border": "#585b70",
+    "editorSuggestWidget.foreground": "#cdd6f4",
+    "editorSuggestWidget.highlightForeground": "#cba6f7",
+    "editorSuggestWidget.selectedBackground": "#313244",
+    "editorWarning.background": "#00000000",
+    "editorWarning.border": "#00000000",
+    "editorWarning.foreground": "#fab387",
+    "editorWhitespace.foreground": "#9399b266",
+    "editorWidget.background": "#181825",
+    "editorWidget.foreground": "#cdd6f4",
+    "editorWidget.resizeBorder": "#585b70",
+    "editorLightBulb.foreground": "#f9e2af",
+    "extensionButton.prominentForeground": "#11111b",
+    "extensionButton.prominentBackground": "#cba6f7",
+    "extensionButton.prominentHoverBackground": "#dfbaff",
+    "extensionBadge.remoteBackground": "#89b4fa",
+    "extensionBadge.remoteForeground": "#11111b",
+    "extensionIcon.starForeground": "#f9e2af",
+    "extensionIcon.verifiedForeground": "#a6e3a1",
+    "extensionIcon.preReleaseForeground": "#f5e0dc",
+    "extensionIcon.sponsorForeground": "#f5c2e7",
+    "gitDecoration.addedResourceForeground": "#a6e3a1",
+    "gitDecoration.conflictingResourceForeground": "#cba6f7",
+    "gitDecoration.deletedResourceForeground": "#f38ba8",
+    "gitDecoration.ignoredResourceForeground": "#6c7086",
+    "gitDecoration.modifiedResourceForeground": "#f9e2af",
+    "gitDecoration.stageDeletedResourceForeground": "#f38ba8",
+    "gitDecoration.stageModifiedResourceForeground": "#f9e2af",
+    "gitDecoration.submoduleResourceForeground": "#89b4fa",
+    "gitDecoration.untrackedResourceForeground": "#a6e3a1",
+    "input.background": "#313244",
+    "input.border": "#00000000",
+    "input.foreground": "#cdd6f4",
+    "input.placeholderForeground": "#cdd6f472",
+    "inputOption.activeBackground": "#89b4fa26",
+    "inputOption.activeBorder": "#11111b33",
+    "inputOption.activeForeground": "#cdd6f4",
+    "inputValidation.errorBackground": "#f38ba8",
+    "inputValidation.errorBorder": "#11111b33",
+    "inputValidation.errorForeground": "#11111b",
+    "inputValidation.infoBackground": "#89b4fa",
+    "inputValidation.infoBorder": "#11111b33",
+    "inputValidation.infoForeground": "#11111b",
+    "inputValidation.warningBackground": "#fab387",
+    "inputValidation.warningBorder": "#11111b33",
+    "inputValidation.warningForeground": "#11111b",
+    "list.activeSelectionBackground": "#45475a",
+    "list.activeSelectionForeground": "#cdd6f4",
+    "list.dropBackground": "#585b7099",
+    "list.focusBackground": "#313244",
+    "list.focusForeground": "#cdd6f4",
+    "list.focusOutline": "#00000000",
+    "list.highlightForeground": "#cba6f7",
+    "list.hoverBackground": "#1e1e2e",
+    "list.hoverForeground": "#cdd6f4",
+    "list.inactiveSelectionBackground": "#45475a",
+    "list.inactiveSelectionForeground": "#cdd6f4",
+    "list.warningForeground": "#f9e2af",
+    "listFilterWidget.background": "#45475a",
+    "listFilterWidget.noMatchesOutline": "#f38ba8",
+    "listFilterWidget.outline": "#00000000",
+    "tree.indentGuidesStroke": "#6c7086",
+    "menu.background": "#1e1e2e",
+    "menu.border": "#1e1e2e7f",
+    "menu.foreground": "#cdd6f4",
+    "menu.selectionBackground": "#585b70",
+    "menu.selectionBorder": "#00000000",
+    "menu.selectionForeground": "#cdd6f4",
+    "menu.separatorBackground": "#585b70",
+    "menubar.selectionBackground": "#45475a",
+    "menubar.selectionForeground": "#cdd6f4",
+    "merge.commonContentBackground": "#45475a",
+    "merge.commonHeaderBackground": "#585b70",
+    "merge.currentContentBackground": "#a6e3a133",
+    "merge.currentHeaderBackground": "#a6e3a166",
+    "merge.incomingContentBackground": "#89b4fa33",
+    "merge.incomingHeaderBackground": "#89b4fa66",
+    "minimap.background": "#1818257f",
+    "minimap.errorHighlight": "#f38ba8",
+    "minimap.findMatchHighlight": "#585b70",
+    "minimap.selectionHighlight": "#585b70",
+    "minimap.warningHighlight": "#f9e2af",
+    "minimapGutter.addedBackground": "#a6e3a1",
+    "minimapGutter.deletedBackground": "#f38ba8",
+    "minimapGutter.modifiedBackground": "#89dceb",
+    "notificationCenter.border": "#cba6f7",
+    "notificationCenterHeader.foreground": "#cdd6f4",
+    "notificationCenterHeader.background": "#181825",
+    "notificationToast.border": "#cba6f7",
+    "notifications.foreground": "#cdd6f4",
+    "notifications.background": "#181825",
+    "notifications.border": "#cba6f7",
+    "notificationLink.foreground": "#89b4fa",
+    "notificationsErrorIcon.foreground": "#f38ba8",
+    "notificationsWarningIcon.foreground": "#fab387",
+    "notificationsInfoIcon.foreground": "#89b4fa",
+    "panel.background": "#1e1e2e",
+    "panel.border": "#585b70",
+    "panelSection.border": "#585b70",
+    "panelSection.dropBackground": "#585b7099",
+    "panelTitle.activeBorder": "#cdd6f4",
+    "panelTitle.activeForeground": "#cdd6f4",
+    "panelTitle.inactiveForeground": "#a6adc8",
+    "peekView.border": "#cba6f7",
+    "peekViewEditor.background": "#181825",
+    "peekViewEditor.matchHighlightBackground": "#fab3873f",
+    "peekViewEditor.matchHighlightBorder": "#fab387",
+    "peekViewEditorGutter.background": "#181825",
+    "peekViewResult.background": "#181825",
+    "peekViewResult.fileForeground": "#cdd6f4",
+    "peekViewResult.lineForeground": "#cdd6f4",
+    "peekViewResult.matchHighlightBackground": "#fab3873f",
+    "peekViewResult.selectionBackground": "#313244",
+    "peekViewResult.selectionForeground": "#cdd6f4",
+    "peekViewTitle.background": "#1e1e2e",
+    "peekViewTitleDescription.foreground": "#bac2deb2",
+    "peekViewTitleLabel.foreground": "#cdd6f4",
+    "pickerGroup.border": "#cba6f7",
+    "pickerGroup.foreground": "#cba6f7",
+    "progressBar.background": "#cba6f7",
+    "scrollbar.shadow": "#11111b",
+    "scrollbarSlider.activeBackground": "#31324466",
+    "scrollbarSlider.background": "#585b707f",
+    "scrollbarSlider.hoverBackground": "#6c7086",
+    "settings.focusedRowBackground": "#585b7033",
+    "settings.headerForeground": "#cdd6f4",
+    "settings.modifiedItemIndicator": "#cba6f7",
+    "settings.dropdownBackground": "#45475a",
+    "settings.dropdownListBorder": "#00000000",
+    "settings.textInputBackground": "#45475a",
+    "settings.textInputBorder": "#00000000",
+    "settings.numberInputBackground": "#45475a",
+    "settings.numberInputBorder": "#00000000",
+    "sideBar.background": "#181825",
+    "sideBar.dropBackground": "#585b7099",
+    "sideBar.foreground": "#cdd6f4",
+    "sideBar.border": "#00000000",
+    "sideBarSectionHeader.background": "#181825",
+    "sideBarSectionHeader.foreground": "#cdd6f4",
+    "sideBarTitle.foreground": "#cba6f7",
+    "sideBarTitle.background": "#11111b",
+    "statusBar.background": "#11111b",
+    "statusBar.foreground": "#cdd6f4",
+    "statusBar.border": "#00000000",
+    "statusBar.noFolderBackground": "#11111b",
+    "statusBar.noFolderForeground": "#cdd6f4",
+    "statusBar.debuggingBackground": "#fab387",
+    "statusBar.debuggingForeground": "#11111b",
+    "statusBarItem.remoteBackground": "#89b4fa",
+    "statusBarItem.remoteForeground": "#11111b",
+    "statusBarItem.activeBackground": "#585b7066",
+    "statusBarItem.hoverBackground": "#585b7033",
+    "statusBarItem.prominentForeground": "#cba6f7",
+    "statusBarItem.prominentBackground": "#00000000",
+    "statusBarItem.prominentHoverBackground": "#585b7033",
+    "statusBarItem.errorForeground": "#f38ba8",
+    "statusBarItem.errorBackground": "#00000000",
+    "statusBarItem.warningForeground": "#fab387",
+    "statusBarItem.warningBackground": "#00000000",
+    "commandCenter.foreground": "#bac2de",
+    "commandCenter.activeForeground": "#cba6f7",
+    "commandCenter.background": "#11111b",
+    "commandCenter.activeBackground": "#585b7033",
+    "commandCenter.border": "#cba6f7",
+    "tab.activeBackground": "#1e1e2e",
+    "tab.activeBorder": "#cba6f7",
+    "tab.activeBorderTop": "#00000000",
+    "tab.activeForeground": "#cba6f7",
+    "tab.border": "#181825",
+    "tab.inactiveBackground": "#181825",
+    "tab.inactiveForeground": "#6c7086",
+    "terminal.ansiBlack": "#6c7086",
+    "terminal.ansiBlue": "#89b4fa",
+    "terminal.ansiBrightBlack": "#7f849c",
+    "terminal.ansiBrightBlue": "#89b4fa",
+    "terminal.ansiBrightCyan": "#89dceb",
+    "terminal.ansiBrightGreen": "#a6e3a1",
+    "terminal.ansiBrightMagenta": "#f5c2e7",
+    "terminal.ansiBrightRed": "#f38ba8",
+    "terminal.ansiBrightWhite": "#cdd6f4",
+    "terminal.ansiBrightYellow": "#f9e2af",
+    "terminal.ansiCyan": "#89dceb",
+    "terminal.ansiGreen": "#a6e3a1",
+    "terminal.ansiMagenta": "#f5c2e7",
+    "terminal.ansiRed": "#f38ba8",
+    "terminal.ansiWhite": "#9399b2",
+    "terminal.ansiYellow": "#f9e2af",
+    "terminal.border": "#585b70",
+    "terminal.foreground": "#cdd6f4",
+    "terminal.dropBackground": "#585b7099",
+    "terminal.selectionBackground": "#585b70",
+    "terminalCursor.background": "#1e1e2e",
+    "terminalCursor.foreground": "#f5e0dc",
+    "titleBar.activeBackground": "#11111b",
+    "titleBar.activeForeground": "#cdd6f4",
+    "titleBar.inactiveBackground": "#11111b",
+    "titleBar.inactiveForeground": "#cdd6f47f",
+    "titleBar.border": "#00000000",
+    "welcomePage.tileBackground": "#181825",
+    "welcomePage.progress.background": "#11111b",
+    "welcomePage.progress.foreground": "#cba6f7",
+    "walkThrough.embeddedEditorBackground": "#1e1e2e4c",
+    "symbolIcon.textForeground": "#cdd6f4",
+    "symbolIcon.arrayForeground": "#fab387",
+    "symbolIcon.booleanForeground": "#cba6f7",
+    "symbolIcon.classForeground": "#f9e2af",
+    "symbolIcon.colorForeground": "#f5c2e7",
+    "symbolIcon.constantForeground": "#fab387",
+    "symbolIcon.constructorForeground": "#b4befe",
+    "symbolIcon.enumeratorForeground": "#f9e2af",
+    "symbolIcon.enumeratorMemberForeground": "#f9e2af",
+    "symbolIcon.eventForeground": "#f5c2e7",
+    "symbolIcon.fieldForeground": "#cdd6f4",
+    "symbolIcon.fileForeground": "#cba6f7",
+    "symbolIcon.folderForeground": "#cba6f7",
+    "symbolIcon.functionForeground": "#89b4fa",
+    "symbolIcon.interfaceForeground": "#f9e2af",
+    "symbolIcon.keyForeground": "#94e2d5",
+    "symbolIcon.keywordForeground": "#cba6f7",
+    "symbolIcon.methodForeground": "#89b4fa",
+    "symbolIcon.moduleForeground": "#cdd6f4",
+    "symbolIcon.namespaceForeground": "#f9e2af",
+    "symbolIcon.nullForeground": "#eba0ac",
+    "symbolIcon.numberForeground": "#fab387",
+    "symbolIcon.objectForeground": "#f9e2af",
+    "symbolIcon.operatorForeground": "#94e2d5",
+    "symbolIcon.packageForeground": "#f2cdcd",
+    "symbolIcon.propertyForeground": "#eba0ac",
+    "symbolIcon.referenceForeground": "#f9e2af",
+    "symbolIcon.snippetForeground": "#f2cdcd",
+    "symbolIcon.stringForeground": "#a6e3a1",
+    "symbolIcon.structForeground": "#94e2d5",
+    "symbolIcon.typeParameterForeground": "#eba0ac",
+    "symbolIcon.unitForeground": "#cdd6f4",
+    "symbolIcon.variableForeground": "#cdd6f4",
+    "charts.foreground": "#cdd6f4",
+    "charts.lines": "#bac2de",
+    "charts.red": "#f38ba8",
+    "charts.blue": "#89b4fa",
+    "charts.yellow": "#f9e2af",
+    "charts.orange": "#fab387",
+    "charts.green": "#a6e3a1",
+    "charts.purple": "#cba6f7",
+    "errorLens.errorBackground": "#f38ba826",
+    "errorLens.errorMessageBackground": "#f38ba826",
+    "errorLens.errorBackgroundLight": "#f38ba826",
+    "errorLens.errorForeground": "#f38ba8",
+    "errorLens.errorForegroundLight": "#f38ba8",
+    "errorLens.warningBackground": "#fab38726",
+    "errorLens.warningMessageBackground": "#fab38726",
+    "errorLens.warningBackgroundLight": "#fab38726",
+    "errorLens.warningForeground": "#fab387",
+    "errorLens.warningForegroundLight": "#fab387",
+    "errorLens.infoBackground": "#89b4fa26",
+    "errorLens.infoMessageBackground": "#89b4fa26",
+    "errorLens.infoBackgroundLight": "#89b4fa26",
+    "errorLens.infoForeground": "#89b4fa",
+    "errorLens.infoForegroundLight": "#89b4fa",
+    "errorLens.hintBackground": "#a6e3a126",
+    "errorLens.hintMessageBackground": "#a6e3a126",
+    "errorLens.hintBackgroundLight": "#a6e3a126",
+    "errorLens.hintForeground": "#a6e3a1",
+    "errorLens.hintForegroundLight": "#a6e3a1",
+    "errorLens.statusBarIconErrorForeground": "#f38ba8",
+    "errorLens.statusBarIconWarningForeground": "#fab387",
+    "errorLens.statusBarErrorForeground": "#f38ba8",
+    "errorLens.statusBarWarningForeground": "#fab387",
+    "errorLens.statusBarInfoForeground": "#89b4fa",
+    "errorLens.statusBarHintForeground": "#a6e3a1",
+    "editorBracketHighlight.foreground1": "#f38ba8",
+    "editorBracketHighlight.foreground2": "#fab387",
+    "editorBracketHighlight.foreground3": "#f9e2af",
+    "editorBracketHighlight.foreground4": "#a6e3a1",
+    "editorBracketHighlight.foreground5": "#74c7ec",
+    "editorBracketHighlight.foreground6": "#cba6f7",
+    "editorBracketHighlight.unexpectedBracket.foreground": "#eba0ac"
+  }
+}


### PR DESCRIPTION
Referenced
- [Shiki · catppuccin/catppuccin · Discussion #1839](https://github.com/catppuccin/catppuccin/discussions/1839)
- [Markdown & MDX 🚀 Astro 문서](https://docs.astro.build/ko/guides/markdown-content/#adding-your-own-theme)

More reference for dark mode (not working for css variables for now) 
- [shiki/docs/themes.md at main · shikijs/shiki](https://github.com/shikijs/shiki/blob/main/docs/themes.md)
- [catppuccin/docs/style-guide.md at main · catppuccin/catppuccin](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md)
- [shiki/docs/themes.md at main · shikijs/shiki](https://github.com/shikijs/shiki/blob/main/docs/themes.md)